### PR TITLE
Config sweeper

### DIFF
--- a/lib/acts_as_audited/audit_sweeper.rb
+++ b/lib/acts_as_audited/audit_sweeper.rb
@@ -3,7 +3,7 @@ module CollectiveIdea #:nodoc:
     module Audited #:nodoc:
       def audit(*models)
         ActiveSupport::Deprecation.warn("#audit is deprecated. Declare #acts_as_audited in your models.", caller)
-        
+
         options = models.extract_options!
 
         # Parse the options hash looking for classes
@@ -20,12 +20,16 @@ module CollectiveIdea #:nodoc:
 end
 
 class AuditSweeper < ActionController::Caching::Sweeper #:nodoc:
+
+  cattr_accessor :current_user_method
+  self.current_user_method = :current_user
+
   def before_create(audit)
     audit.user ||= current_user
   end
 
   def current_user
-    controller.send :current_user if controller.respond_to?(:current_user, true)
+    controller.send self.class.current_user_method if controller.respond_to?(self.class.current_user_method, true)
   end
 end
 


### PR DESCRIPTION
It is great that acts_as_audited assumes the _current_user_ method in the controller hierarchy, however it should be configurable at least.

In a current application we use both _current_login_ and _current_user_ as helpers for the application. _current_login_ is an instance of one of many classes that are allowed to login. Certain classes can masquerade as others, ie: an Admin can masquerade as a User. We then use _current_user_ to build a reasonable string representation for use in the audits: _admin@example.com_ or _admin@example.com > user@example.com_, allowing the audits to track the masquerading too.

The problem comes when so many other plugins also depend on _current_user_ to be present, for different reasons. In our case, declartive_authorization also assumes _current_user_ and expects an object. We have no way of configuring any one of the two plugins to change their behavior.

This simple patch allows the AuditSweeper to be configured to use a helper method other than _current_user_, for edge cases like this.
