### PR TITLE
Fixed issue #3

### DIFF
--- a/lib/acts_as_audited/audit.rb
+++ b/lib/acts_as_audited/audit.rb
@@ -14,7 +14,12 @@ class Audit < ActiveRecord::Base
 
   before_create :set_version_number, :set_audit_user
 
-  serialize :changes
+  # ActiveRecord::Base#changes is an existing method, so before serializing the +changes+ column,
+  # the existing +changes+ method is undefined. The overridden +changes+ method pertained to 
+  # dirty attributes, but will not affect the partial updates functionality as that's based on
+  # an underlying +changed_attributes+ method, not +changes+ itself.
+  undef_method :changes
+  serialize :changes, Hash
 
   cattr_accessor :audited_class_names
   self.audited_class_names = Set.new


### PR DESCRIPTION
This patch fixes issue #3 [1] by undefining the built-in ActiveRecord::Dirty #changes method before applying the serialization macro. Since audits are mostly write-once the built-in #changes method becomes a bit obsolete, and so there's no harm done with this patch. Also, the underlying dirty API doesn't use this method, so it's perfectly safe to undefine.

I saw this trick used in vestal_versions [2] and I figured it was good enough, so I copied it verbatim (including the very insightful comment).

I ran the tests and they are passing for all Rails 2.x versions, but not Rails 3 (which I figure wasn't supported before either).

[1] http://github.com/collectiveidea/acts_as_audited/issues#issue/3
[2] http://github.com/laserlemon/vestal_versions/blob/master/lib/vestal_versions/version.rb#L13
