### PR TITLE
ActsAsAudited.ignored_attributes accessor to set ignored attributes

### DIFF
--- a/lib/acts_as_audited.rb
+++ b/lib/acts_as_audited.rb
@@ -26,6 +26,14 @@ require 'active_record'
 module ActsAsAudited
   VERSION = '2.0.0.rc7'
 
+  class << self
+    attr_accessor_with_default :ignored_attributes, ['lock_version',
+                                                     'created_at',
+                                                     'updated_at',
+                                                     'created_on',
+                                                     'updated_on']
+  end
+
   mattr_accessor :current_user_method
   # The method to be called to return the current user for logging in the audits.
   @@current_user_method = :current_user

--- a/lib/acts_as_audited/auditor.rb
+++ b/lib/acts_as_audited/auditor.rb
@@ -59,8 +59,7 @@ module ActsAsAudited
         if options[:only]
           except = self.column_names - options[:only].flatten.map(&:to_s)
         else
-          except = [self.primary_key, inheritance_column, 'lock_version',
-            'created_at', 'updated_at', 'created_on', 'updated_on']
+          except = [self.primary_key, inheritance_column] + ActsAsAudited.ignored_attributes
           except |= Array(options[:except]).collect(&:to_s) if options[:except]
         end
         write_inheritable_attribute :non_audited_columns, except

--- a/spec/acts_as_audited_spec.rb
+++ b/spec/acts_as_audited_spec.rb
@@ -17,6 +17,15 @@ describe ActsAsAudited::Auditor do
       end
     end
 
+    it "should be configurable which attributes are not audited" do
+      ActsAsAudited.ignored_attributes = ['delta', 'top_secret', 'created_at']
+      class Secret < ActiveRecord::Base
+        acts_as_audited
+      end
+
+      Secret.non_audited_columns.should include('delta', 'top_secret', 'created_at')
+    end
+
     it "should not save non-audited columns" do
       create_user.audits.first.audited_changes.keys.any? { |col| ['created_at', 'updated_at', 'password'].include?( col ) }.should be_false
     end


### PR DESCRIPTION
We have some attributes in our Application which are distributed over different tables but should never go into the audits-table (like the delta attribute for ThinkingSphinx). I changed the source slightly to make the list of ignored-attributes configurable on the ActsAsAudited Module.

Cheers
-- Yves
