### PR TITLE
1.1 stable

### DIFF
--- a/generators/audited_migration_update/USAGE
+++ b/generators/audited_migration_update/USAGE
@@ -1,5 +1,5 @@
 Description:
-	The audited migration generator creates a migration to update the audits table to allow for audit comments. It should only be used if upgrading acts_as_audited from a versino which does not permit audit comments
+	The audited migration generator creates a migration to update the audits table to allow for audit comments. It should only be used if upgrading acts_as_audited from a version which does not permit audit comments
 
 Example:
     ./script/generate audited_migration_upgrade update_audits_table

--- a/lib/acts_as_audited.rb
+++ b/lib/acts_as_audited.rb
@@ -100,7 +100,7 @@ module CollectiveIdea #:nodoc:
           Audit.audited_class_names << self.to_s
           
           if options[:parent]
-            parent_class = options[:parent].to_s.classify.constantize
+            parent_class = reflect_on_association(options[:parent]).active_record
             auditable_children_association = ( class_name.tableize.singularize + '_audits' ).to_sym
             
             parent_class.class_eval <<-EOS


### PR DESCRIPTION
in 1.1, if the association name is not derivative of the ActiveRecord class name, then it can't find the ActiveRecord class.

for example:

```ruby
class Foo < ActiveRecord::Base
  acts_as_audited
end

class FooRelationship < ActiveRecord::Base
  belongs_to :parent_foo, :class_name => "Foo"
  belongs_to :child_foo, :class_name => "Foo"
  acts_as_audited :parent => :parent_foo # this will throw an exception
end
```