### PR TITLE
Fixed "Stack level too deep" on Rails 3.1.rc1

### DIFF
--- a/lib/acts_as_audited/audit.rb
+++ b/lib/acts_as_audited/audit.rb
@@ -12,7 +12,7 @@ require 'set'
 class Audit < ActiveRecord::Base
   belongs_to :auditable, :polymorphic => true
   belongs_to :user, :polymorphic => true
-  belongs_to :association, :polymorphic => true
+  belongs_to :associated, :polymorphic => true
 
   before_create :set_version_number, :set_audit_user
 

--- a/lib/acts_as_audited/auditor.rb
+++ b/lib/acts_as_audited/auditor.rb
@@ -93,7 +93,7 @@ module ActsAsAudited
       end
 
       def has_associated_audits
-        has_many :associated_audits, :as => :association, :class_name => "Audit"
+        has_many :associated_audits, :as => :associated, :class_name => "Audit"
       end
 
     end
@@ -210,7 +210,7 @@ module ActsAsAudited
       end
 
       def write_audit(attrs)
-        attrs[:association] = self.send(audit_associated_with) unless audit_associated_with.nil?
+        attrs[:associated] = self.send(audit_associated_with) unless audit_associated_with.nil?
         self.audit_comment = nil
         self.audits.create attrs if auditing_enabled
       end

--- a/lib/generators/acts_as_audited/templates/install.rb
+++ b/lib/generators/acts_as_audited/templates/install.rb
@@ -3,8 +3,8 @@ class <%= migration_class_name %> < ActiveRecord::Migration
     create_table :audits, :force => true do |t|
       t.column :auditable_id, :integer
       t.column :auditable_type, :string
-      t.column :association_id, :integer
-      t.column :association_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
       t.column :user_id, :integer
       t.column :user_type, :string
       t.column :username, :string
@@ -17,7 +17,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
     end
 
     add_index :audits, [:auditable_id, :auditable_type], :name => 'auditable_index'
-    add_index :audits, [:association_id, :association_type], :name => 'association_index'
+    add_index :audits, [:associated_id, :associated_type], :name => 'associated_index'
     add_index :audits, [:user_id, :user_type], :name => 'user_index'
     add_index :audits, :created_at
   end

--- a/lib/generators/acts_as_audited/templates/rename_association_to_associated.rb
+++ b/lib/generators/acts_as_audited/templates/rename_association_to_associated.rb
@@ -1,0 +1,23 @@
+class <%= migration_class_name %> < ActiveRecord::Migration
+  def self.up
+    if index_exists? :audits, [:association_id, :association_type], :name => 'association_index'
+      remove_index :audits, :name => 'association_index'
+    end
+
+    rename_column :audits, :association_id, :associated_id
+    rename_column :audits, :association_type, :associated_type
+
+    add_index :audits, [:associated_id, :associated_type], :name => 'associated_index'
+  end
+
+  def self.down
+    if index_exists? :audits, [:associated_id, :associated_type], :name => 'associated_index'
+      remove_index :audits, :name => 'associated_index'
+    end
+
+    rename_column :audits, :associated_type, :association_type
+    rename_column :audits, :associated_id, :association_id
+
+    add_index :audits, [:association_id, :association_type], :name => 'association_index'
+  end
+end

--- a/lib/generators/acts_as_audited/upgrade_generator.rb
+++ b/lib/generators/acts_as_audited/upgrade_generator.rb
@@ -48,8 +48,14 @@ module ActsAsAudited
           if columns.include?('auditable_parent_id')
             yield :rename_parent_to_association
           else
-            yield :add_association_to_audits
+            unless columns.include?( 'associated_id' )
+              yield :add_association_to_audits
+            end
           end
+        end
+
+        if columns.include?( 'association_id' )
+          yield :rename_association_to_associated
         end
       end
     end

--- a/spec/acts_as_audited_spec.rb
+++ b/spec/acts_as_audited_spec.rb
@@ -175,17 +175,17 @@ describe ActsAsAudited::Auditor do
     let(:owned_company) { OwnedCompany.create!(:name => 'The auditors', :owner => owner) }
 
     it "should record the associated object on create" do
-      owned_company.audits.first.association.should == owner
+      owned_company.audits.first.associated.should == owner
     end
 
     it "should store the associated object on update" do
       owned_company.update_attribute(:name, 'The Auditors')
-      owned_company.audits.last.association.should == owner
+      owned_company.audits.last.associated.should == owner
     end
 
     it "should store the associated object on destroy" do
       owned_company.destroy
-      owned_company.audits.last.association.should == owner
+      owned_company.audits.last.associated.should == owner
     end
   end
 

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -27,8 +27,8 @@ ActiveRecord::Schema.define(:version => 0) do
   create_table :audits, :force => true do |t|
     t.column :auditable_id, :integer
     t.column :auditable_type, :string
-    t.column :association_id, :integer
-    t.column :association_type, :string
+    t.column :associated_id, :integer
+    t.column :associated_type, :string
     t.column :user_id, :integer
     t.column :user_type, :string
     t.column :username, :string
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(:version => 0) do
   end
 
   add_index :audits, [:auditable_id, :auditable_type], :name => 'auditable_index'
-  add_index :audits, [:association_id, :association_type], :name => 'association_index'
+  add_index :audits, [:associated_id, :associated_type], :name => 'associated_index'
   add_index :audits, [:user_id, :user_type], :name => 'user_index'
   add_index :audits, :created_at
 end

--- a/test/db/version_5.rb
+++ b/test/db/version_5.rb
@@ -1,0 +1,18 @@
+ActiveRecord::Schema.define do
+  create_table :audits, :force => true do |t|
+    t.column :auditable_id, :integer
+    t.column :auditable_type, :string
+    t.column :user_id, :integer
+    t.column :user_type, :string
+    t.column :username, :string
+    t.column :action, :string
+    t.column :audited_changes, :text
+    t.column :version, :integer, :default => 0
+    t.column :comment, :string
+    t.column :created_at, :datetime
+    t.column :remote_address, :string
+    t.column :association_id, :integer
+    t.column :association_type, :string
+  end
+end
+

--- a/test/upgrade_generator_test.rb
+++ b/test/upgrade_generator_test.rb
@@ -41,7 +41,7 @@ class UpgradeGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  test "should add 'associated_id' and 'associated_type' to audits table" do
+  test "should add 'association_id' and 'association_type' to audits table" do
     load_schema 4
 
     run_generator %w(upgrade)
@@ -49,6 +49,17 @@ class UpgradeGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/add_association_to_audits.rb" do |content|
       assert_match /add_column :audits, :association_id, :integer/, content
       assert_match /add_column :audits, :association_type, :string/, content
+    end
+  end
+
+  test "should rename 'association_id' to 'associated_id' and 'association_type' to 'associated_type'" do
+    load_schema 5
+
+    run_generator %w(upgrade)
+
+    assert_migration "db/migrate/rename_association_to_associated.rb" do |content|
+      assert_match /rename_column :audits, :association_id, :associated_id/, content
+      assert_match /rename_column :audits, :association_type, :associated_type/, content
     end
   end
 end


### PR DESCRIPTION
Renamed 'association' to 'associated' as Rails 3.1 introduces conflicting 'association' method.
