### PR TITLE
Mass assignment error

### DIFF
--- a/lib/acts_as_audited/audit.rb
+++ b/lib/acts_as_audited/audit.rb
@@ -21,6 +21,8 @@ class Audit < ActiveRecord::Base
   cattr_accessor :audited_class_names
   self.audited_class_names = Set.new
 
+  attr_accessible :action, :audited_changes, :comment
+
   # Order by ver
   default_scope order(:version)
   scope :descending, reorder("version DESC")


### PR DESCRIPTION
Without this fix on save I got this mass assignment error: Mass assignment error: ["action", "audited_changes", "comment"]

This becomes fixed by adding the line "attr_accessible :action, :audited_changes, :comment" to the audit.rb.
