### PR TITLE
Added file extension for README.rdoc.

### DIFF
--- a/acts_as_audited.gemspec
+++ b/acts_as_audited.gemspec
@@ -13,13 +13,13 @@ Gem::Specification.new do |s|
   s.email = %q{brandon@opensoul.org}
   s.extra_rdoc_files = [
     "LICENSE",
-     "README"
+     "README.rdoc"
   ]
   s.files = [
     ".gitignore",
      "CHANGELOG",
      "LICENSE",
-     "README",
+     "README.rdoc",
      "Rakefile",
      "VERSION",
      "acts_as_audited.gemspec",


### PR DESCRIPTION
The .gemspec file was missing README.rdoc's file extensions. Rubygems was giving this error:

```
acts_as_audited at somecode/vendor/bundle/ruby/1.8/bundler/gems/acts_as_audited-de6031feaf1e did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["README"] are not files
```

I added the file extension to README.rdoc and the gem now builds and rubygems does not complain.
