### PR TITLE
attr_accessor_with_default is deprecated

### DIFF
--- a/lib/acts_as_audited.rb
+++ b/lib/acts_as_audited.rb
@@ -27,11 +27,14 @@ module ActsAsAudited
   VERSION = '2.0.0'
 
   class << self
-    attr_accessor_with_default :ignored_attributes, ['lock_version',
-                                                     'created_at',
-                                                     'updated_at',
-                                                     'created_on',
-                                                     'updated_on']
+    attr_writer :ignored_attributes
+    def ignored_attributes
+      @ignored_attributes ||= ['lock_version',
+                               'created_at',
+                               'updated_at',
+                               'created_on',
+                               'updated_on']
+    end
   end
 
   mattr_accessor :current_user_method


### PR DESCRIPTION
attr_accessor_with_default is deprected in rails 3.1
