### PR TITLE
Fix problem when using acts_as_audited in conjunction with devise

### DIFF
--- a/lib/acts_as_audited.rb
+++ b/lib/acts_as_audited.rb
@@ -27,11 +27,14 @@ module ActsAsAudited
   VERSION = '2.0.0'
 
   class << self
-    attr_accessor_with_default :ignored_attributes, ['lock_version',
-                                                     'created_at',
-                                                     'updated_at',
-                                                     'created_on',
-                                                     'updated_on']
+    attr_writer :ignored_attributes
+    def ignored_attributes
+      @ignored_attributes ||= ['lock_version',
+                                'created_at',
+                                'updated_at',
+                                'created_on',
+                                'updated_on']
+    end
   end
 
   mattr_accessor :current_user_method

--- a/lib/acts_as_audited/auditor.rb
+++ b/lib/acts_as_audited/auditor.rb
@@ -48,7 +48,7 @@ module ActsAsAudited
       #
       def acts_as_audited(options = {})
         # don't allow multiple calls
-        return if self.included_modules.include?(ActsAsAudited::Auditor::InstanceMethods)
+        return if !self.table_exists? or self.included_modules.include?(ActsAsAudited::Auditor::InstanceMethods)
 
         options = {:protect => accessible_attributes.empty?}.merge(options)
 


### PR DESCRIPTION
Because `devise` gem will add a `devise_for :users` into `routes.rb`, and this call will eventually load the User model definition, so if there's a **:only** option defined in User model's _acts_as_audited_ call like:

``` ruby
class User < ActiveRecord::Base
  acts_as_audited :only => [:name, :email]
end
```

and if you migrate the database from scratch, you'll run into the problem, because in `Auditor.rb`:

``` ruby
if options[:only]
  except = self.column_names - options[:only].flatten.map(&:to_s)
else
  except = [self.primary_key, inheritance_column, 'lock_version',
            'created_at', 'updated_at', 'created_on', 'updated_on']
  except |= Array(options[:except]).collect(&:to_s) if options[:except]
end
```

will call **ActiveRecord::Base.column_names** method which need the db schema in place, which when you do the migration from scratch, is not available yet. So I just simply added a check to see whether the table is defined or not at the beginning of _acts_as_audited_ method.
