### PR TITLE
Introduce non_auditable_columns lazy method.

### DIFF
--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -29,6 +29,22 @@ describe Audited::Auditor, :adapter => :active_record do
     it "should not save non-audited columns" do
       create_active_record_user.audits.first.audited_changes.keys.any? { |col| ['created_at', 'updated_at', 'password'].include?( col ) }.should be_false
     end
+
+    it "should not call column_names on initialization" do
+      model = Class.new(Models::ActiveRecord::BlankUser)
+      model.should_not_receive(:column_names)
+      model.audited :only => [:name]
+      Audited::Adapters::ActiveRecord::Audit.audited_class_names.delete(model.to_s)
+    end
+
+    it "should access column names one time" do
+      model = Class.new(Models::ActiveRecord::BlankUser)
+      model.audited :only => [:name]
+      model.should_receive(:column_names).once
+        .and_return(Models::ActiveRecord::BlankUser.column_names)
+      2.times { model.non_audited_columns }
+      Audited::Adapters::ActiveRecord::Audit.audited_class_names.delete(model.to_s)
+    end
   end
 
   describe :new do

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -13,6 +13,10 @@ module Models
       end
     end
 
+    class BlankUser < ::ActiveRecord::Base
+      self.table_name = :users
+    end
+
     class CommentRequiredUser < ::ActiveRecord::Base
       self.table_name = :users
       audited :comment_required => true


### PR DESCRIPTION
This is adopted version of pull request #78. I do not understand why it was not applied before...

Let me clarify what use case it resolves. When an user of audited creates a model and pass :only option, e.g.

```ruby
class User < ActiveRecord::Base
  audited :only => [:administrator]
end
```

then `rake db:migrate` will constantly fail because Audited will call `column_names` on a model without table.

I am sure this is a typical use case and every user of audited will be frustrated when it will encounter such an error. ;)