### PR TITLE
Add alias to Audit class and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The installation process depends on what ORM your app is using.
 Add the appropriate gem to your Gemfile:
 
 ```ruby
-gem "audited-activerecord", "~> 3.0"
+gem "audited-activerecord", "~> 3.0.0.rc1"
 ```
 
 Then, from your Rails app directory, create the `audits` table:
@@ -54,7 +54,7 @@ Upgrading will only make changes if changes are needed.
 ### MongoMapper
 
 ```ruby
-gem "audited-mongo_mapper", "~> 3.0"
+gem "audited-mongo_mapper", "~> 3.0.0.rc1"
 ```
 
 ## Usage

--- a/lib/audited/adapters/active_record.rb
+++ b/lib/audited/adapters/active_record.rb
@@ -10,6 +10,8 @@ end
 
 ::ActiveRecord::Base.send :include, Audited::Auditor
 
+::Audit = Audited::Adapters::ActiveRecord::Audit
+
 Audited.audit_class = Audited::Adapters::ActiveRecord::Audit
 
 require 'audited/sweeper'


### PR DESCRIPTION
Hi,

This pull request aims at fixing the following issues:

- #101 - Add alias for the Audit class, otherwise one would have to use `Audited::Adapters::ActiveRecord::Audit`.

- #100 - I had exactly the same issue. I fixed the docs in order to reflect the latest released gem.

Do you agree with these changes?