### PR TITLE
Ensure controller isn't leaked in ActiveController around filter

### DIFF
--- a/lib/audited/sweeper.rb
+++ b/lib/audited/sweeper.rb
@@ -4,13 +4,13 @@ module Audited
 
     attr_accessor :controller
 
-    def before(controller)
-      self.controller = controller
-      true
-    end
-
-    def after(controller)
-      self.controller = nil
+    def around(controller)
+      begin
+        self.controller = controller
+        yield
+      ensure
+        self.controller = nil
+      end
     end
 
     def before_create(audit)


### PR DESCRIPTION
I found that in some cases the after callback was not being executed in audited. This had the side effect of leaking self.controller in tests and causing warden to show random failures. I changed the before/after callbacks to be an around callback with a begin/ensure block.

---
John Downey
Braintree Developer