### PR TITLE
Reset audited_user when yield raises exception

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -29,12 +29,9 @@ module Audited
       # for background operations that require audit information.
       def as_user(user, &block)
         Thread.current[:audited_user] = user
-
-        yieldval = yield
-
+        yield
+      ensure
         Thread.current[:audited_user] = nil
-
-        yieldval
       end
 
       # @private

--- a/spec/audited/adapters/active_record/audit_spec.rb
+++ b/spec/audited/adapters/active_record/audit_spec.rb
@@ -185,6 +185,15 @@ describe Audited::Adapters::ActiveRecord::Audit, :adapter => :active_record do
       end.should == 42
     end
 
+    it "should reset audited_user when the yield block raises an exception" do
+      expect {
+        Audited.audit_class.as_user('foo') do
+          raise StandardError
+        end
+      }.to raise_exception
+      Thread.current[:audited_user].should be_nil
+    end
+
   end
 
   describe "mass assignment" do

--- a/spec/audited/adapters/mongo_mapper/audit_spec.rb
+++ b/spec/audited/adapters/mongo_mapper/audit_spec.rb
@@ -188,6 +188,15 @@ describe Audited::Adapters::MongoMapper::Audit, :adapter => :mongo_mapper do
       end.should == 42
     end
 
+    it "should reset audited_user when the yield block raises an exception" do
+      expect {
+        Audited.audit_class.as_user('foo') do
+          raise StandardError
+        end
+      }.to raise_exception
+      Thread.current[:audited_user].should be_nil
+    end
+
   end
 
 end


### PR DESCRIPTION
Because if it's not set to nil, all audits made from the sweeper will
use the user from this block instead of current_user, until
Audit.as_user is called again.
