### PR TITLE
Audit.as_user with a crash block can generate error aduited user

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -28,13 +28,12 @@ module Audited
       # by +user+. This method is hopefully threadsafe, making it ideal
       # for background operations that require audit information.
       def as_user(user, &block)
-        Thread.current[:audited_user] = user
-
-        yieldval = yield
-
-        Thread.current[:audited_user] = nil
-
-        yieldval
+        begin
+          Thread.current[:audited_user] = user
+          yield
+        ensure
+          Thread.current[:audited_user] = nil
+        end
       end
 
       # @private

--- a/spec/audited/adapters/active_record/audit_spec.rb
+++ b/spec/audited/adapters/active_record/audit_spec.rb
@@ -132,6 +132,16 @@ describe Audited::Adapters::ActiveRecord::Audit, :adapter => :active_record do
 
   describe "as_user" do
 
+    it "should guarantee the audited_user is nil " do
+      begin
+        Audited.audit_class.as_user("someone") do
+          raise "broken as_user"
+        end
+      rescue
+        Thread.current[:audited_user].should == nil
+      end
+    end
+
     it "should record user objects" do
       Audited.audit_class.as_user(user) do
         company = Models::ActiveRecord::Company.create :name => 'The auditors'


### PR DESCRIPTION
In rails app

``` ruby
   Audit.as_user('system autogenerate') { a_create_record_block_may_crash }
```

if the block crashed, then the Thread.current[:audited_user] will always be 'system autogenerate'. Then user visit other page, make other requests  and it makes subsequent audit creations use wrong user.
This commit can fix it. 
Thanks.
