### PR TITLE
Add test to ensure which attributes are not audited when uses ':only'

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -43,7 +43,13 @@ module Audited
         class_attribute :audit_associated_with, :instance_writer => false
 
         if options[:only]
-          except = self.column_names - options[:only].flatten.map(&:to_s)
+          only_columns = options[:only].flatten.map(&:to_s)
+
+          except = if self.table_exists?
+            self.column_names - only_columns
+          else
+            only_columns
+          end
         else
           except = default_ignored_attributes + Audited.ignored_attributes
           except |= Array(options[:except]).collect(&:to_s) if options[:except]

--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -26,6 +26,14 @@ describe Audited::Auditor, :adapter => :active_record do
       expect(Secret.non_audited_columns).to include('delta', 'top_secret', 'created_at')
     end
 
+    it "should be configurable which attributes are not audited when uses only" do
+      class AdminUser < ::ActiveRecord::Base
+        audited :only => ['email', 'name']
+      end
+
+      AdminUser.non_audited_columns.should include('email', 'name')
+    end
+
     it "should not save non-audited columns" do
       expect(create_active_record_user.audits.first.audited_changes.keys.any? { |col| ['created_at', 'updated_at', 'password'].include?( col ) }).to eq(false)
     end


### PR DESCRIPTION
Hi,

I'm using `audited` in a rails app with devise gem and every time that I have to run the migrations from the scratch the audited gem raises a error.

I figured out that is because I need to use the `:only` option and because the table wasn't created yet.

So, this pull request is a fix for this problem.

:) 
