### PR TITLE
Prevent audit create errors on duplicate destroys

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -207,7 +207,7 @@ module Audited
 
       def audit_destroy
         write_audit(:action => 'destroy', :audited_changes => audited_attributes,
-                    :comment => audit_comment)
+                    :comment => audit_comment) unless self.respond_to?(:destroyed?) && self.destroyed?
       end
 
       def write_audit(attrs)

--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -194,6 +194,16 @@ describe Audited::Auditor, :adapter => :active_record do
         on_create_update.destroy
       }.to_not change( Audited.audit_class, :count )
     end
+    
+    it "should not throw an error when record is destroyed twice" do
+      expect {
+        @user.destroy
+        @user.destroy
+      }.to change( Audited.audit_class, :count )
+
+      @user.audits.size.should be(2)
+    end
+
   end
 
   describe "associated with" do


### PR DESCRIPTION
This is a fix for #139 to prevent audit creation errors when a record is destroyed multiple times with ActiveRecord.
