### PR TITLE
Sweeper code isn't thread-safe.

### DIFF
--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -3,6 +3,10 @@ module Audited
 
   class << self
     attr_accessor :ignored_attributes, :current_user_method, :audit_class
+
+    def store
+      Thread.current[:audited_store] ||= {}
+    end
   end
 
   @ignored_attributes = %w(lock_version created_at updated_at created_on updated_on)

--- a/lib/audited/sweeper.rb
+++ b/lib/audited/sweeper.rb
@@ -2,8 +2,6 @@ module Audited
   class Sweeper < ActiveModel::Observer
     observe Audited.audit_class
 
-    attr_accessor :controller
-
     def before(controller)
       self.controller = controller
       true
@@ -34,6 +32,14 @@ module Audited
         observer.update(:before_create, self)
       end
       klass.send(:before_create, callback_meth)
+    end
+
+    def controller
+      ::Audited.store[:current_controller]
+    end
+
+    def controller=(value)
+      ::Audited.store[:current_controller] = value
     end
   end
 end

--- a/spec/audited/adapters/active_record/sweeper_spec.rb
+++ b/spec/audited/adapters/active_record/sweeper_spec.rb
@@ -72,3 +72,26 @@ describe AuditsController, :adapter => :active_record do
 
   end
 end
+
+
+describe Audited::Sweeper, :adapter => :active_record do
+
+  it "should be thread-safe" do
+    t1 = Thread.new do
+      sleep 0.5
+      Audited::Sweeper.instance.controller = 'thread1 controller instance'
+      Audited::Sweeper.instance.controller.should eq('thread1 controller instance')
+    end
+
+    t2 = Thread.new do
+      Audited::Sweeper.instance.controller = 'thread2 controller instance'
+      sleep 1
+      Audited::Sweeper.instance.controller.should eq('thread2 controller instance')
+    end
+
+    t1.join; t2.join
+
+    Audited::Sweeper.instance.controller.should be_nil
+  end
+
+end

--- a/spec/audited/adapters/mongo_mapper/sweeper_spec.rb
+++ b/spec/audited/adapters/mongo_mapper/sweeper_spec.rb
@@ -72,3 +72,26 @@ describe AuditsController, :adapter => :mongo_mapper do
 
   end
 end
+
+
+describe Audited::Sweeper, :adapter => :mongo_mapper do
+
+  it "should be thread-safe" do
+    t1 = Thread.new do
+      sleep 0.5
+      Audited::Sweeper.instance.controller = 'thread1 controller instance'
+      Audited::Sweeper.instance.controller.should eq('thread1 controller instance')
+    end
+
+    t2 = Thread.new do
+      Audited::Sweeper.instance.controller = 'thread2 controller instance'
+      sleep 1
+      Audited::Sweeper.instance.controller.should eq('thread2 controller instance')
+    end
+
+    t1.join; t2.join
+
+    Audited::Sweeper.instance.controller.should be_nil
+  end
+
+end


### PR DESCRIPTION
Sweeper is a singleton so its @controller variable may be changed or nullified by a different thread before the before_create method is called on an audit instance. 
It results in an audit with wrong user and remote_address being created.
