### PR TITLE
Skip execution of audited if the table doesn't exist

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -46,6 +46,8 @@ module Audited
       def audited(options = {})
         # don't allow multiple calls
         return if self.included_modules.include?(Audited::Auditor::AuditedInstanceMethods)
+        # table doesn't exist, we are in a rake task for migration or alike
+        return if !self.table_exists?
 
         class_attribute :non_audited_columns,   :instance_writer => false
         class_attribute :auditing_enabled,      :instance_writer => false


### PR DESCRIPTION
Currently, line 55 on auditor.rb will fail if the table doesn't exist yet. Added a check if the table exists, if not, return from the method.

This case should only appear when setting up a new database (using a rake task) so we don't need the audit anyway.