### PR TITLE
Add documentation for ":on" option, to limit which actions are audited

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ class User < ActiveRecord::Base
 end
 ```
 
+### Specifying callbacks
+
+By default, a new audit is created for any Create, Update or Destroy action. You can, however, limit the actions audited.
+
+```ruby
+class User < ActiveRecord::Base
+  # All fields and actions
+  # audited
+
+  # Single field, only audit Update and Destroy (not Create)
+  # audited only: :name, on: [:update, :destroy]
+end
+```
+
 ### Comments
 
 You can attach comments to each audit using an `audit_comment` attribute on your model.


### PR DESCRIPTION
There's a nice feature to limit which actions are audited, to avoid, for example, auditing of "create". It's not documented, so I added a small snippet about it in the README.
