### PR TITLE
Audited IP needs to be the one originally making the request, not the load balancer's

### DIFF
--- a/lib/audited/sweeper.rb
+++ b/lib/audited/sweeper.rb
@@ -15,7 +15,7 @@ module Audited
 
     def before_create(audit)
       audit.user ||= current_user
-      audit.remote_address = controller.try(:request).try(:ip)
+      audit.remote_address = controller.try(:request).try(:remote_ip)
     end
 
     def current_user


### PR DESCRIPTION
In the case an application is running behind a load balancer, audited will log all requests's remote_address as if the load balancer made the request, not an individual user.

This trivial patch avoids this and saves the content of the header X-Forwarded-For if the request was made from a load balancer to really know who was originally making the request. If the request does not contain this header (for instance, someone truly making a request directly to your application without load balancers, REMOTE_ADDR is set as the remote_address, which is the only original behavior.
