### PR TITLE
Fix: Destroy on unsaved object should not audit

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -207,7 +207,7 @@ module Audited
 
       def audit_destroy
         write_audit(:action => 'destroy', :audited_changes => audited_attributes,
-                    :comment => audit_comment)
+                    :comment => audit_comment) unless self.new_record?
       end
 
       def write_audit(attrs)

--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -196,6 +196,21 @@ describe Audited::Auditor, :adapter => :active_record do
     end
   end
 
+  describe "on destroy with unsaved object" do
+    before do
+      @user = build_user
+      @user.new_record?.should be_true
+    end
+
+    it "should not audit on 'destroy'" do
+      expect {
+        @user.destroy
+      }.to_not raise_error
+
+      @user.audits.should be_empty
+    end
+  end
+
   describe "associated with" do
     let(:owner) { Models::ActiveRecord::Owner.create(:name => 'Models::ActiveRecord::Owner') }
     let(:owned_company) { Models::ActiveRecord::OwnedCompany.create!(:name => 'The auditors', :owner => owner) }

--- a/spec/audited_spec_helpers.rb
+++ b/spec/audited_spec_helpers.rb
@@ -5,6 +5,10 @@ module AuditedSpecHelpers
     klass.create({:name => 'Brandon', :username => 'brandon', :password => 'password'}.merge(attrs))
   end
 
+  def build_user(attrs = {})
+    User.new({:name => 'darth', :username => 'darth', :password => 'noooooooo'}.merge(attrs))
+  end
+
   def create_versions(n = 2, use_mongo = false)
     klass = use_mongo ? Models::MongoMapper::User : Models::ActiveRecord::User
 


### PR DESCRIPTION
If a record is new and destroy is called on it, an audit for the destroy should not be created.  It causes an ActiveRecord exception:

```
  ActiveRecord::RecordNotSaved: You cannot call create unless the parent is saved
```

This is a continuation of this pull request:  https://github.com/collectiveidea/audited/pull/79.  This version includes a (previously) failing spec.  