### PR TITLE
Ensure `.without_auditing` reset auditing status

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -237,7 +237,9 @@ module Audited
       def without_auditing(&block)
         auditing_was_enabled = auditing_enabled
         disable_auditing
-        block.call.tap { enable_auditing if auditing_was_enabled }
+        block.call
+      ensure
+        enable_auditing if auditing_was_enabled
       end
 
       def disable_auditing

--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -409,6 +409,11 @@ describe Audited::Auditor, :adapter => :active_record do
         Models::ActiveRecord::User.without_auditing { Models::ActiveRecord::User.create!( :name => 'Brandon' ) }
       }.to_not change( Audited.audit_class, :count )
     end
+
+    it "should reset auditing status even it raises an exception" do
+      Models::ActiveRecord::User.without_auditing { raise } rescue nil
+      expect(Models::ActiveRecord::User.auditing_enabled).to eq(true)
+    end
   end
 
   describe "comment required" do

--- a/spec/audited/adapters/mongo_mapper/auditor_spec.rb
+++ b/spec/audited/adapters/mongo_mapper/auditor_spec.rb
@@ -414,6 +414,11 @@ describe Audited::Auditor, :adapter => :mongo_mapper do
         Models::MongoMapper::User.without_auditing { Models::MongoMapper::User.create!( :name => 'Brandon' ) }
       }.to_not change( Audited.audit_class, :count )
     end
+
+    it "should reset auditing status even it raises an exception" do
+      Models::MongoMapper::User.without_auditing { raise } rescue nil
+      expect(Models::MongoMapper::User.auditing_enabled).to eq(true)
+    end
   end
 
   describe "comment required" do


### PR DESCRIPTION
Without using `ensure`, `enable_auditing` will not get called when a
block passed to `.without_auditing` raises an exception.