### PR TITLE
Don't run if the table doesn't exist yet

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -46,6 +46,8 @@ module Audited
       def audited(options = {})
         # don't allow multiple calls
         return if self.included_modules.include?(Audited::Auditor::AuditedInstanceMethods)
+        #don't break if instantiated before the table exists (during rake db tasks)
+        return if !self.table_exists?
 
         class_attribute :non_audited_columns,   :instance_writer => false
         class_attribute :auditing_enabled,      :instance_writer => false


### PR DESCRIPTION
Fixes issue of observers and factories instantiating the models
before the table exists, causing column lookup to throw an
exception
