### PR TITLE
Kill default scope

### DIFF
--- a/lib/audited/adapters/active_record/audit.rb
+++ b/lib/audited/adapters/active_record/audit.rb
@@ -21,8 +21,8 @@ module Audited
 
         serialize :audited_changes
 
-        default_scope         ->{ order(:version)}
-        scope :descending,    ->{ reorder("version DESC")}
+        scope :ascending,     ->{ order(:version) }
+        scope :descending,    ->{ order("version DESC")}
         scope :creates,       ->{ where({:action => 'create'})}
         scope :updates,       ->{ where({:action => 'update'})}
         scope :destroys,      ->{ where({:action => 'destroy'})}

--- a/lib/audited/adapters/active_record/audit.rb
+++ b/lib/audited/adapters/active_record/audit.rb
@@ -21,11 +21,11 @@ module Audited
 
         serialize :audited_changes
 
-        scope :ascending,     ->{ order(:version) }
-        scope :descending,    ->{ order("version DESC")}
-        scope :creates,       ->{ where({:action => 'create'})}
-        scope :updates,       ->{ where({:action => 'update'})}
-        scope :destroys,      ->{ where({:action => 'destroy'})}
+        scope :ascending,     ->{ reorder(version: :asc) }
+        scope :descending,    ->{ reorder(version: :desc)}
+        scope :creates,       ->{ where(action: 'create')}
+        scope :updates,       ->{ where(action: 'update')}
+        scope :destroys,      ->{ where(action: 'destroy')}
 
         scope :up_until,      ->(date_or_time){where("created_at <= ?", date_or_time) }
         scope :from_version,  ->(version){where(['version >= ?', version]) }

--- a/lib/audited/adapters/active_record/audit.rb
+++ b/lib/audited/adapters/active_record/audit.rb
@@ -33,7 +33,7 @@ module Audited
         scope :auditable_finder, ->(auditable_id, auditable_type){where(auditable_id: auditable_id, auditable_type: auditable_type)}
         # Return all audits older than the current one.
         def ancestors
-          self.class.where(['auditable_id = ? and auditable_type = ? and version <= ?',
+          self.class.ascending.where(['auditable_id = ? and auditable_type = ? and version <= ?',
             auditable_id, auditable_type, version])
         end
 

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -58,7 +58,7 @@ module Audited
 
         attr_accessor :audit_comment
 
-        has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name
+        has_many :audits, -> { order(version: :asc) }, as: :auditable, class_name: Audited.audit_class.name
         Audited.audit_class.audited_class_names << self.to_s
 
         after_create  :audit_create if !options[:on] || (options[:on] && options[:on].include?(:create))

--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -66,7 +66,7 @@ describe Audited::Auditor, :adapter => :active_record do
 
     it "should set the action to create" do
       expect(user.audits.first.action).to eq('create')
-      expect(Audited.audit_class.creates.reorder(:id).last).to eq(user.audits.first)
+      expect(Audited.audit_class.creates.order(:id).last).to eq(user.audits.first)
       expect(user.audits.creates.count).to eq(1)
       expect(user.audits.updates.count).to eq(0)
       expect(user.audits.destroys.count).to eq(0)
@@ -109,7 +109,7 @@ describe Audited::Auditor, :adapter => :active_record do
     it "should set the action to 'update'" do
       @user.update_attributes :name => 'Changed'
       expect(@user.audits.last.action).to eq('update')
-      expect(Audited.audit_class.updates.reorder(:id).last).to eq(@user.audits.last)
+      expect(Audited.audit_class.updates.order(:id).last).to eq(@user.audits.last)
       expect(@user.audits.updates.last).to eq(@user.audits.last)
     end
 
@@ -169,7 +169,7 @@ describe Audited::Auditor, :adapter => :active_record do
       @user.destroy
 
       expect(@user.audits.last.action).to eq('destroy')
-      expect(Audited.audit_class.destroys.reorder(:id).last).to eq(@user.audits.last)
+      expect(Audited.audit_class.destroys.order(:id).last).to eq(@user.audits.last)
       expect(@user.audits.destroys.last).to eq(@user.audits.last)
     end
 


### PR DESCRIPTION
Seems to cause more problems than it solves. Easy to re-add for those people who want it.

- [x] kill default scope
- [x] add a default order by version to the `has_many :audits`