### PR TITLE
Support for around_audit callback

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -65,10 +65,12 @@ module Audited
         before_update :audit_update if !options[:on] || (options[:on] && options[:on].include?(:update))
         before_destroy :audit_destroy if !options[:on] || (options[:on] && options[:on].include?(:destroy))
 
-        # Define and set an after_audit callback. This might be useful if you want
-        # to notify a party after the audit has been created.
+        # Define and set after_audit and around_audit callbacks. This might be useful if you want
+        # to notify a party after the audit has been created or if you want to access the newly-created
+        # audit.
         define_callbacks :audit
         set_callback :audit, :after, :after_audit, :if => lambda { self.respond_to?(:after_audit) }
+        set_callback :audit, :around, :around_audit, :if => lambda { self.respond_to?(:around_audit) }
 
         attr_accessor :version
 

--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -519,4 +519,13 @@ describe Audited::Auditor, :adapter => :active_record do
     end
   end
 
+  describe "around_audit" do
+    let( :user ) { user = Models::ActiveRecord::UserWithAfterAudit.new }
+
+    it "should invoke around_audit callback on create" do
+      expect(user.around_attr).to be_nil
+      expect(user.save).to eq(true)
+      expect(user.around_attr).to eq(user.audits.last)
+    end
+  end
 end

--- a/spec/audited/adapters/mongo_mapper/auditor_spec.rb
+++ b/spec/audited/adapters/mongo_mapper/auditor_spec.rb
@@ -526,4 +526,13 @@ describe Audited::Auditor, :adapter => :mongo_mapper do
     end
   end
 
+  describe "around_audit" do
+    let( :user ) { user = Models::MongoMapper::UserWithAfterAudit.new }
+
+    it "should invoke around_audit callback on create" do
+      expect(user.around_attr).to be_nil
+      expect(user.save).to eq(true)
+      expect(user.around_attr).to eq(user.audits.last)
+    end
+  end
 end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -38,10 +38,14 @@ module Models
     class UserWithAfterAudit < ::ActiveRecord::Base
       self.table_name = :users
       audited
-      attr_accessor :bogus_attr
+      attr_accessor :bogus_attr, :around_attr
 
       def after_audit
         self.bogus_attr = "do something"
+      end
+
+      def around_audit
+        self.around_attr = yield
       end
     end
 

--- a/spec/support/mongo_mapper/models.rb
+++ b/spec/support/mongo_mapper/models.rb
@@ -94,10 +94,14 @@ module Models
       timestamps!
 
       audited
-      attr_accessor :bogus_attr
+      attr_accessor :bogus_attr, :around_attr
 
       def after_audit
         self.bogus_attr = "do something"
+      end
+
+      def around_audit
+        self.around_attr = yield
       end
     end
 


### PR DESCRIPTION
In some scenarios, it might be useful for you to be able to have access to an immediately-created audit for a specific model. Ideally, you would pass your audit to the `after_audit` callback. However, the only way in which `ActiveSupport::Callbacks` supports access to the result of an executed block is via use of the `around` callback, which allows you to assign the result of the `yield` operation to retrieve the result of your action.

This changeset adds an `around_audit` callback to enable this scenario.
