### PR TITLE
Handle serialized attributes to fix #191 

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -78,7 +78,6 @@ module Audited
     def old_attributes
       (audited_changes || {}).inject({}.with_indifferent_access) do |attrs,(attr,values)|
         attrs[attr] = (action == 'update') ? values.first : values
-
         attrs
       end
     end

--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -69,7 +69,7 @@ module Audited
     # Returns a hash of the changed attributes with the new values
     def new_attributes
       (audited_changes || {}).inject({}.with_indifferent_access) do |attrs,(attr,values)|
-        attrs[attr] = values.is_a?(Array) ? values.last : values
+        attrs[attr] = (action == 'update') ? values.last : values
         attrs
       end
     end
@@ -77,7 +77,7 @@ module Audited
     # Returns a hash of the changed attributes with the old values
     def old_attributes
       (audited_changes || {}).inject({}.with_indifferent_access) do |attrs,(attr,values)|
-        attrs[attr] = Array(values).first
+        attrs[attr] = (action == 'update') ? values.first : values
 
         attrs
       end

--- a/spec/audited/adapters/active_record/audit_spec.rb
+++ b/spec/audited/adapters/active_record/audit_spec.rb
@@ -122,7 +122,7 @@ describe Audited::Adapters::ActiveRecord::Audit, :adapter => :active_record do
   describe "new_attributes" do
 
     it "should return a hash of the new values" do
-      new_attributes = Audited.audit_class.new(:audited_changes => {:a => [1, 2], :b => [3, 4]}).new_attributes
+      new_attributes = Audited.audit_class.new(:action => 'update', :audited_changes => {:a => [1, 2], :b => [3, 4]}).new_attributes
       expect(new_attributes).to eq({'a' => 2, 'b' => 4})
     end
 
@@ -131,7 +131,7 @@ describe Audited::Adapters::ActiveRecord::Audit, :adapter => :active_record do
   describe "old_attributes" do
 
     it "should return a hash of the old values" do
-      old_attributes = Audited.audit_class.new(:audited_changes => {:a => [1, 2], :b => [3, 4]}).old_attributes
+      old_attributes = Audited.audit_class.new(:action => 'update', :audited_changes => {:a => [1, 2], :b => [3, 4]}).old_attributes
       expect(old_attributes).to eq({'a' => 1, 'b' => 3})
     end
 

--- a/spec/audited/adapters/mongo_mapper/audit_spec.rb
+++ b/spec/audited/adapters/mongo_mapper/audit_spec.rb
@@ -130,7 +130,7 @@ describe Audited::Adapters::MongoMapper::Audit, :adapter => :mongo_mapper do
   describe "new_attributes" do
 
     it "should return a hash of the new values" do
-      new_attributes = Audited.audit_class.new(:audited_changes => {:a => [1, 2], :b => [3, 4]}).new_attributes
+      new_attributes = Audited.audit_class.new(:action => 'update', :audited_changes => {:a => [1, 2], :b => [3, 4]}).new_attributes
       expect(new_attributes).to eq({'a' => 2, 'b' => 4})
     end
 
@@ -139,7 +139,7 @@ describe Audited::Adapters::MongoMapper::Audit, :adapter => :mongo_mapper do
   describe "old_attributes" do
 
     it "should return a hash of the old values" do
-      old_attributes = Audited.audit_class.new(:audited_changes => {:a => [1, 2], :b => [3, 4]}).old_attributes
+      old_attributes = Audited.audit_class.new(:action => 'update', :audited_changes => {:a => [1, 2], :b => [3, 4]}).old_attributes
       expect(old_attributes).to eq({'a' => 1, 'b' => 3})
     end
 


### PR DESCRIPTION
Consider the action when reconstructing the attributes so that for 'create' and 'destroy' actions we don't mistakenly think the array in `audited_changes` contains an old/new value.
