### PR TITLE
ensure enable back auditing on exception

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -234,10 +234,12 @@ module Audited
       #     @foo.save
       #   end
       #
-      def without_auditing(&block)
+      def without_auditing
         auditing_was_enabled = auditing_enabled
         disable_auditing
-        block.call.tap { enable_auditing if auditing_was_enabled }
+        yield
+      ensure
+        enable_auditing if auditing_was_enabled
       end
 
       def disable_auditing


### PR DESCRIPTION
AuditedClassMethods#without_auditing would not enable auditing on exception

using ensure block will enable back even when exception is raised inside the block