### PR TITLE
Rename revision accessor from :version to :audit_version

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -36,7 +36,7 @@ module Audited
       def reconstruct_attributes(audits)
         attributes = {}
         result = audits.collect do |audit|
-          attributes.merge!(audit.new_attributes).merge!(:version => audit.version)
+          attributes.merge!(audit.new_attributes).merge!(:audit_version => audit.version)
           yield attributes if block_given?
         end
         block_given? ? result : attributes
@@ -62,7 +62,7 @@ module Audited
     def revision
       clazz = auditable_type.constantize
       (clazz.find_by_id(auditable_id) || clazz.new).tap do |m|
-        self.class.assign_revision_attributes(m, self.class.reconstruct_attributes(ancestors).merge({ :version => version }))
+        self.class.assign_revision_attributes(m, self.class.reconstruct_attributes(ancestors).merge({ :audit_version => version }))
       end
     end
 

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -72,7 +72,7 @@ module Audited
         set_callback :audit, :after, :after_audit, :if => lambda { self.respond_to?(:after_audit) }
         set_callback :audit, :around, :around_audit, :if => lambda { self.respond_to?(:around_audit) }
 
-        attr_accessor :version
+        attr_accessor :audit_version
 
         extend Audited::Auditor::AuditedClassMethods
         include Audited::Auditor::AuditedInstanceMethods
@@ -105,7 +105,7 @@ module Audited
       #
       #   user.revisions.each do |revision|
       #     user.name
-      #     user.version
+      #     user.audit_version
       #   end
       #
       def revisions(from_version = 1)
@@ -177,8 +177,8 @@ module Audited
 
       def audits_to(version = nil)
         if version == :previous
-          version = if self.version
-                      self.version - 1
+          version = if self.audit_version
+                      self.audit_version - 1
                     else
                       previous = audits.descending.offset(1).first
                       previous ? previous.version : 1

--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -253,7 +253,7 @@ describe Audited::Auditor, :adapter => :active_record do
 
     it "should return an Array of Users" do
       expect(user.revisions).to be_a_kind_of( Array )
-      user.revisions.each { |version| expect(version).to be_a_kind_of Models::ActiveRecord::User }
+      user.revisions.each { |revision| expect(revision).to be_a_kind_of Models::ActiveRecord::User }
     end
 
     it "should have one revision for a new record" do
@@ -316,21 +316,21 @@ describe Audited::Auditor, :adapter => :active_record do
     it "should find the given revision" do
       revision = user.revision(3)
       expect(revision).to be_a_kind_of( Models::ActiveRecord::User )
-      expect(revision.version).to eq(3)
+      expect(revision.audit_version).to eq(3)
       expect(revision.name).to eq('Foobar 3')
     end
 
     it "should find the previous revision with :previous" do
       revision = user.revision(:previous)
-      expect(revision.version).to eq(4)
+      expect(revision.audit_version).to eq(4)
       #expect(revision).to eq(user.revision(4))
       expect(revision.attributes).to eq(user.revision(4).attributes)
     end
 
     it "should be able to get the previous revision repeatedly" do
       previous = user.revision(:previous)
-      expect(previous.version).to eq(4)
-      expect(previous.revision(:previous).version).to eq(3)
+      expect(previous.audit_version).to eq(4)
+      expect(previous.revision(:previous).audit_version).to eq(3)
     end
 
     it "should be able to set protected attributes" do
@@ -400,7 +400,7 @@ describe Audited::Auditor, :adapter => :active_record do
       audit.created_at = 1.hour.ago
       audit.save!
       user.update_attributes :name => 'updated'
-      expect(user.revision_at( 2.minutes.ago ).version).to eq(1)
+      expect(user.revision_at( 2.minutes.ago ).audit_version).to eq(1)
     end
 
     it "should be nil if given a time before audits" do

--- a/spec/audited/adapters/mongo_mapper/auditor_spec.rb
+++ b/spec/audited/adapters/mongo_mapper/auditor_spec.rb
@@ -257,7 +257,7 @@ describe Audited::Auditor, :adapter => :mongo_mapper do
 
     it "should return an Array of Users" do
       expect(user.revisions).to be_a_kind_of( Array )
-      user.revisions.each { |version| expect(version).to be_a_kind_of(Models::MongoMapper::User) }
+      user.revisions.each { |revision| expect(revision).to be_a_kind_of(Models::MongoMapper::User) }
     end
 
     it "should have one revision for a new record" do
@@ -320,21 +320,21 @@ describe Audited::Auditor, :adapter => :mongo_mapper do
     it "should find the given revision" do
       revision = user.revision(3)
       expect(revision).to be_a_kind_of( Models::MongoMapper::User )
-      expect(revision.version).to eq(3)
+      expect(revision.audit_version).to eq(3)
       expect(revision.name).to eq('Foobar 3')
     end
 
     it "should find the previous revision with :previous" do
       revision = user.revision(:previous)
-      expect(revision.version).to eq(4)
+      expect(revision.audit_version).to eq(4)
       #expect(revision).to eq(user.revision(4))
       expect(revision.attributes).to eq(user.revision(4).attributes)
     end
 
     it "should be able to get the previous revision repeatedly" do
       previous = user.revision(:previous)
-      expect(previous.version).to eq(4)
-      expect(previous.revision(:previous).version).to eq(3)
+      expect(previous.audit_version).to eq(4)
+      expect(previous.revision(:previous).audit_version).to eq(3)
     end
 
     it "should be able to set protected attributes" do
@@ -405,7 +405,7 @@ describe Audited::Auditor, :adapter => :mongo_mapper do
       audit.created_at = 1.hour.ago
       audit.save!
       user.update_attributes :name => 'updated'
-      expect(user.revision_at( 2.minutes.ago ).version).to eq(1)
+      expect(user.revision_at( 2.minutes.ago ).audit_version).to eq(1)
     end
 
     it "should be nil if given a time before audits" do


### PR DESCRIPTION
preventing clashing with existing attribute name