### PR TITLE
Evaluate column black-/whitelist lazily

### DIFF
--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -18,12 +18,13 @@ describe Audited::Auditor, :adapter => :active_record do
     end
 
     it "should be configurable which attributes are not audited" do
-      Audited.ignored_attributes = ['delta', 'top_secret', 'created_at']
-      class Secret < ::ActiveRecord::Base
-        audited
-      end
+      with_ignored_attributes(['delta', 'top_secret', 'created_at']) do
+        class Secret < ::ActiveRecord::Base
+          audited
+        end
 
-      Secret.non_audited_columns.should include('delta', 'top_secret', 'created_at')
+        Secret.non_audited_columns.should include('delta', 'top_secret', 'created_at')
+      end
     end
 
     it "should not save non-audited columns" do

--- a/spec/audited/adapters/mongo_mapper/auditor_spec.rb
+++ b/spec/audited/adapters/mongo_mapper/auditor_spec.rb
@@ -18,13 +18,14 @@ describe Audited::Auditor, :adapter => :mongo_mapper do
     end
 
     it "should be configurable which attributes are not audited" do
-      Audited.ignored_attributes = ['delta', 'top_secret', 'created_at']
-      class Secret
-        include MongoMapper::Document
-        audited
-      end
+      with_ignored_attributes(['delta', 'top_secret', 'created_at']) do
+        class Secret
+          include MongoMapper::Document
+          audited
+        end
 
-      Secret.non_audited_columns.should include('delta', 'top_secret', 'created_at')
+        Secret.non_audited_columns.should include('delta', 'top_secret', 'created_at')
+      end
     end
 
     it "should not save non-audited columns" do

--- a/spec/audited_spec_helpers.rb
+++ b/spec/audited_spec_helpers.rb
@@ -28,4 +28,12 @@ module AuditedSpecHelpers
     create_versions(n, true)
   end
 
+  def with_ignored_attributes(attributes)
+    old_attributes = Audited.ignored_attributes
+    Audited.ignored_attributes = attributes
+    yield
+  ensure
+    Audited.ignored_attributes = old_attributes
+  end
+
 end


### PR DESCRIPTION
## What changes?

With this PR the column selectors (`only` and `except`) are evaluated lazily on the first call of `non_audited_columns` instead of being evaluated immediately when calling `audited` (which happens by solely requireing the audited model).

## Why? What was the problem?

The reason for that change is that calling methods like `column_names` and `primary_key` require the database to be properly set-up. With an empty database those calls will fail and therefore it was impossible to require an audited model before its database table was setup properly, because the call to `audited` would immediately call those methods.

This does not seem to be a problem under normal, ActiveRecord-only conditions. However, we use both: Mongoid and ActiveRecord in our project.
During `rake db:setup` our Mongoid seems to require all files under `app/models` at some point, which will cause trouble, because when running `db:setup` there will (obviously) be no tables and therefore rake will fail as soon as one of the audited models is required.

By evaluating the excluded columns lazily, requiring a model will not cause any database interaction. I think this is a good thing in general, though I don't know if there are any ActiveRecord imposed rules on when you are allowed to call to the database.

## Note on target branch

Since we are using audited for a Rails 3 project I am issuing this PR against your 3.0 branch. Feel free to merge this PR whereever you see fit. I am not sure if you are even maintaining the 3.0 releases anymore. Still I would apprechiate if this could become part of Audited 3.x, since it would allow us to use a proper release again instead of relying on an own fork.