### PR TITLE
fix 'raise_error without specific error' warning

### DIFF
--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -190,9 +190,9 @@ describe Audited::Audit do
     it "should reset audited_user when the yield block raises an exception" do
       expect {
         Audited.audit_class.as_user('foo') do
-          raise StandardError
+          raise StandardError.new('expected')
         end
-      }.to raise_exception
+      }.to raise_exception('expected')
       expect(Thread.current[:audited_user]).to be_nil
     end
 


### PR DESCRIPTION
Small change, getting used to the codebase.

Here's the full rspec warning:

WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<StandardError: StandardError>. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /Users/bronson/audited/spec/audited/audit_spec.rb:191:in `block (3 levels) in <top (required)>'.