### PR TITLE
Remove audit#version

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -8,7 +8,6 @@ module Audited
   # * <tt>action</tt>: one of create, update, or delete
   # * <tt>audited_changes</tt>: a serialized hash of all the changes
   # * <tt>comment</tt>: a comment set with the audit
-  # * <tt>version</tt>: the version of the model
   # * <tt>request_uuid</tt>: a uuid based that allows audits from the same controller request
   # * <tt>created_at</tt>: Time that the change was performed
   #
@@ -25,20 +24,18 @@ module Audited
     self.audited_class_names = Set.new
 
     serialize :audited_changes
-
-    scope :ascending,     ->{ reorder(version: :asc) }
-    scope :descending,    ->{ reorder(version: :desc)}
+    scope :ascending,     ->{ reorder(id: :asc) }
+    scope :descending,    ->{ reorder(id: :desc)}
     scope :creates,       ->{ where(action: 'create')}
     scope :updates,       ->{ where(action: 'update')}
     scope :destroys,      ->{ where(action: 'destroy')}
 
     scope :up_until,      ->(date_or_time){where("created_at <= ?", date_or_time) }
-    scope :from_version,  ->(version){where(['version >= ?', version]) }
-    scope :to_version,    ->(version){where(['version <= ?', version]) }
+
     scope :auditable_finder, ->(auditable_id, auditable_type){where(auditable_id: auditable_id, auditable_type: auditable_type)}
     # Return all audits older than the current one.
     def ancestors
-      self.class.ascending.auditable_finder(auditable_id, auditable_type).to_version(version)
+      self.class.ascending.auditable_finder(auditable_id, auditable_type).where("id <= ?", id)
     end
 
     # Return an instance of what the object looked like at this revision. If
@@ -46,7 +43,7 @@ module Audited
     def revision
       clazz = auditable_type.constantize
       (clazz.find_by_id(auditable_id) || clazz.new).tap do |m|
-        self.class.assign_revision_attributes(m, self.class.reconstruct_attributes(ancestors).merge(version: version))
+        self.class.assign_revision_attributes(m, self.class.reconstruct_attributes(ancestors))
       end
     end
 
@@ -101,11 +98,23 @@ module Audited
       Thread.current[:audited_user] = nil
     end
 
+    def self.from_version(version)
+      version ||= 1
+      version_id = ascending.offset(version - 1).first
+      where("id >= ?", version_id)
+    end
+
+    def self.to_version(version)
+      version ||= 1
+      version_id = ascending.offset(version - 1).first
+      where("id <= ?", version_id)
+    end
+
     # @private
     def self.reconstruct_attributes(audits)
       attributes = {}
       result = audits.collect do |audit|
-        attributes.merge!(audit.new_attributes).merge!(version: audit.version)
+        attributes.merge!(audit.new_attributes)
         yield attributes if block_given?
       end
       block_given? ? result : attributes
@@ -128,8 +137,7 @@ module Audited
     private
 
     def set_version_number
-      max = self.class.auditable_finder(auditable_id, auditable_type).descending.first.try(:version) || 0
-      self.version = max + 1
+      nil
     end
 
     def set_audit_user

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -58,7 +58,7 @@ module Audited
 
         attr_accessor :audit_comment
 
-        has_many :audits, -> { order(version: :asc) }, as: :auditable, class_name: Audited.audit_class.name
+        has_many :audits, -> { order(id: :asc) }, as: :auditable, class_name: Audited.audit_class.name
         Audited.audit_class.audited_class_names << to_s
 
         after_create :audit_create if !options[:on] || (options[:on] && options[:on].include?(:create))
@@ -181,12 +181,7 @@ module Audited
 
       def audits_to(version = nil)
         if version == :previous
-          version = if self.version
-                      self.version - 1
-                    else
-                      previous = audits.descending.offset(1).first
-                      previous ? previous.version : 1
-                    end
+          version = self.audits.count - 1
         end
         audits.to_version(version)
       end

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -49,8 +49,8 @@ describe Audited::Audit do
       user = Models::ActiveRecord::User.create name: "1"
       5.times {|i| user.update_attribute :name, (i + 2).to_s }
 
-      user.audits.each do |audit|
-        expect(audit.revision.name).to eq(audit.version.to_s)
+      user.audits.each_with_index do |audit, i|
+        expect(audit.revision.name).to eq("#{i+1}")
       end
     end
 
@@ -76,16 +76,6 @@ describe Audited::Audit do
       expect(revision.name).to eq(user.name)
       expect(revision).to be_a_new_record
     end
-  end
-
-  it "should set the version number on create" do
-    user = Models::ActiveRecord::User.create! name: "Set Version Number"
-    expect(user.audits.first.version).to eq(1)
-    user.update_attribute :name, "Set to 2"
-    expect(user.audits(true).first.version).to eq(1)
-    expect(user.audits(true).last.version).to eq(2)
-    user.destroy
-    expect(Audited.audit_class.where(auditable_type: "Models::ActiveRecord::User", auditable_id: user.id).last.version).to eq(3)
   end
 
   it "should set the request uuid on create" do

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -316,21 +316,12 @@ describe Audited::Auditor do
     it "should find the given revision" do
       revision = user.revision(3)
       expect(revision).to be_a_kind_of( Models::ActiveRecord::User )
-      expect(revision.version).to eq(3)
       expect(revision.name).to eq('Foobar 3')
     end
 
     it "should find the previous revision with :previous" do
       revision = user.revision(:previous)
-      expect(revision.version).to eq(4)
-      #expect(revision).to eq(user.revision(4))
       expect(revision.attributes).to eq(user.revision(4).attributes)
-    end
-
-    it "should be able to get the previous revision repeatedly" do
-      previous = user.revision(:previous)
-      expect(previous.version).to eq(4)
-      expect(previous.revision(:previous).version).to eq(3)
     end
 
     it "should be able to set protected attributes" do
@@ -396,11 +387,12 @@ describe Audited::Auditor do
     let( :user ) { create_user }
 
     it "should find the latest revision before the given time" do
+      nom = user.name
       audit = user.audits.first
       audit.created_at = 1.hour.ago
       audit.save!
       user.update_attributes :name => 'updated'
-      expect(user.revision_at( 2.minutes.ago ).version).to eq(1)
+      expect(user.revision_at( 2.minutes.ago ).name).to eq(nom)
     end
 
     it "should be nil if given a time before audits" do


### PR DESCRIPTION
- remove calls to set the version number
- update scopes that rely on version number to find ancestor versions.

These changes only remove one feature that was supported by the parent gem: calling `obj.revision(:previous)` repeatedly. So recursing previous versions to find a change wont work anymore.  

```
while(some_revision_im_looking_for) do
  version = obj.revision(:previous)
end
``` 

will instead have to loop and check the revision index specifically:

```
revision_num = obj.audits.count
while(some_cond) do
  revision_num -= 1
  version = object.revision(revision_num)
end
```

I haven't tested this in our app yet, just removing the version column here and making the specs pass again. 