### PR TITLE
update README so the Rails generators work

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Audited is currently ActiveRecord-only. In a previous life, Audited worked with 
 Add the gem to your Gemfile:
 
 ```ruby
-gem "audited", "~> 4.0"
+gem 'audited', '~> 4.0'
+gem 'audited-activerecord', '~> 4.2'
 ```
 
 Then, from your Rails app directory, create the `audits` table:


### PR DESCRIPTION
This change corresponds to README mention that `audited` only works with ActiveRecord (https://github.com/collectiveidea/audited#supported-orms)