### PR TITLE
Mention revision features in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ audit.action # => "update"
 audit.audited_changes # => {"name"=>["Steve", "Ryan"]}
 ```
 
+You can get previous versions of a record by index or date, or list all
+revisions.
+
+```ruby
+user.revisions
+user.revision(1)
+user.revision_at(Date.parse("2016-01-01"))
+```
+
 ### Specifying columns
 
 By default, a new audit is created for any attribute changes. You can, however, limit the columns to be considered.


### PR DESCRIPTION
I assumed these didn't exist and found them looking into what would be
needed to implement them!

There's probably a safety feature needed that raises if the first audit isn't a `create` type - otherwise you get bogus results (the newest version of the record, except for updates that have happened.) This scenario happens if you retrofit audited on to a class that has existing records.

I used the following migration which appears to work(?), would be nice if there was an official way of doing this (unless there is and I just missed it?).

```ruby
# The audited gem doesn't expect to be added to already existing records.
# Without backfilling a "create" audit event, methods such as `revision_at`
# don't work correctly.
#
# There doesn't appear to be a public API or recommended way to do this.
# I'm guessing from reading the audited code.
Record.find_each do |record|
  if record.audits.any?
    warn "Invalid state, record #{record.id} already has audits!"
    next
  end

  # This is usually called in the after_create hook.
  record.send(:audit_create)

  # By back-dating the audit, `revision_at` will work correctly.
  record.audits[0].update_attributes!(created_at: record.created_at)
end
```