### PR TITLE
Make temporary disabling of auditing threadsafe

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -39,7 +39,6 @@ module Audited
         return if self.included_modules.include?(Audited::Auditor::AuditedInstanceMethods)
 
         class_attribute :non_audited_columns,   :instance_writer => false
-        class_attribute :auditing_enabled,      :instance_writer => false
         class_attribute :audit_associated_with, :instance_writer => false
 
         if options[:only]
@@ -224,9 +223,20 @@ module Audited
       def empty_callback #:nodoc:
       end
 
+      def auditing_enabled
+        self.class.auditing_enabled
+      end
+
+      def auditing_enabled= val
+        self.class.auditing_enabled = val
+      end
+
     end # InstanceMethods
 
     module AuditedClassMethods
+      def self.extended(base)
+        base.const_set('AUDIT_VAR_NAME', "#{base.name.tableize}_auditing_enabled")
+      end
       # Returns an array of columns that are audited. See non_audited_columns
       def audited_columns
         self.columns.select { |c| !non_audited_columns.include?(c.name) }
@@ -260,6 +270,18 @@ module Audited
       # @see Audit#as_user.
       def audit_as( user, &block )
         Audited.audit_class.as_user( user, &block )
+      end
+
+      def auditing_enabled
+        if (val = Thread.current[const_get('AUDIT_VAR_NAME')]).nil?
+          true # default if not set yet
+        else
+          val
+        end
+      end
+
+      def auditing_enabled= val
+        Thread.current[const_get('AUDIT_VAR_NAME')] = val
       end
     end
   end

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -234,9 +234,6 @@ module Audited
     end # InstanceMethods
 
     module AuditedClassMethods
-      def self.extended(base)
-        base.const_set('AUDIT_VAR_NAME', "#{base.name.tableize}_auditing_enabled")
-      end
       # Returns an array of columns that are audited. See non_audited_columns
       def audited_columns
         self.columns.select { |c| !non_audited_columns.include?(c.name) }
@@ -273,15 +270,11 @@ module Audited
       end
 
       def auditing_enabled
-        if (val = Thread.current[const_get('AUDIT_VAR_NAME')]).nil?
-          true # default if not set yet
-        else
-          val
-        end
+        Audited.store.fetch("#{name.tableize}_auditing_enabled", true)
       end
 
       def auditing_enabled= val
-        Thread.current[const_get('AUDIT_VAR_NAME')] = val
+        Audited.store["#{name.tableize}_auditing_enabled"] = val
       end
     end
   end

--- a/spec/audited/adapters/active_record/auditor_spec.rb
+++ b/spec/audited/adapters/active_record/auditor_spec.rb
@@ -426,6 +426,34 @@ describe Audited::Auditor, :adapter => :active_record do
       Models::ActiveRecord::User.without_auditing { raise } rescue nil
       expect(Models::ActiveRecord::User.auditing_enabled).to eq(true)
     end
+
+    it "should be thread safe using a #without_auditing block" do
+      begin
+        t1 = Thread.new do
+          expect(Models::ActiveRecord::User.auditing_enabled).to eq(true)
+          Models::ActiveRecord::User.without_auditing do
+            expect(Models::ActiveRecord::User.auditing_enabled).to eq(false)
+            Models::ActiveRecord::User.create!( :name => 'Bart' )
+            sleep 1
+            expect(Models::ActiveRecord::User.auditing_enabled).to eq(false)
+          end
+          expect(Models::ActiveRecord::User.auditing_enabled).to eq(true)
+        end
+
+        t2 = Thread.new do
+          sleep 0.5
+          expect(Models::ActiveRecord::User.auditing_enabled).to eq(true)
+          Models::ActiveRecord::User.create!( :name => 'Lisa' )
+        end
+        t1.join
+        t2.join
+
+        expect(Models::ActiveRecord::User.find_by_name('Bart').audits.count).to eq(0)
+        expect(Models::ActiveRecord::User.find_by_name('Lisa').audits.count).to eq(1)
+      rescue ActiveRecord::StatementInvalid
+        STDERR.puts "Thread safety tests cannot be run with SQLite"
+      end
+    end
   end
 
   describe "comment required" do


### PR DESCRIPTION
For compatibility with, e.g., sidekiq.

Otherwise, one thread disables audits other threads that should be auditing don't, until the first thread completes.