### PR TITLE
Alias RSpec matcher methods for RSpec 3

### DIFF
--- a/lib/audited/rspec_matchers.rb
+++ b/lib/audited/rspec_matchers.rb
@@ -76,6 +76,8 @@ module Audited
         "Did not expect #{@expectation}"
       end
 
+      alias_method :failure_message_when_negated, :negative_failure_message
+
       def description
         description = "audited"
         description += " associated with #{@options[:associated_with]}" if @options.key?(:associated_with)
@@ -148,6 +150,8 @@ module Audited
       def negative_failure_message
         "Expected #{model_class} to not have associated audits"
       end
+
+      alias_method :failure_message_when_negated, :negative_failure_message
 
       def description
         "has associated audits"


### PR DESCRIPTION
Similar to pull #185, this pull should eliminate the deprecation
warnings RSpec emits when using the audited RSpec matchers. Aliasing
the methods should leave it compatible with earlier versions of RSpec
as well.
