### PR TITLE
New release for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.2.4
   - 2.3.1
   - ruby-head
-  - jruby-head
 env:
   - DB=SQLITE
   - DB=POSTGRES
@@ -18,11 +17,8 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-head
   exclude:
     - rvm: 2.1
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: jruby-head
       gemfile: gemfiles/rails50.gemfile
   fast_finish: true
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 rvm:
   - 2.1
   - 2.2.4
-  - 2.3.0
+  - 2.3.1
   - ruby-head
   - jruby-head
 env:

--- a/Appraisals
+++ b/Appraisals
@@ -18,7 +18,7 @@ appraise 'rails42' do
 end
 
 appraise 'rails50' do
-  gem 'rails', '>= 5.0.0.alpha', '< 5.1'
+  gem 'rails', '~> 5.0.0'
 
   # The following needs to point to Github until the release of 0.1.3
   gem 'rails-observers', :github => 'rails/rails-observers', :branch => 'master'

--- a/Appraisals
+++ b/Appraisals
@@ -23,10 +23,4 @@ appraise 'rails50' do
   # The following needs to point to Github until the release of 0.1.3
   gem 'rails-observers', :github => 'rails/rails-observers', :branch => 'master'
 
-  # The following need to point to Github until the release of version 3.5.0 to resolve deprecation warnings
-  gem 'rspec-core', :github => 'rspec/rspec-core', :branch => 'master'
-  gem 'rspec-rails', :github => 'rspec/rspec-rails', :branch => 'master'
-  gem 'rspec-mocks', :github => 'rspec/rspec-mocks', :branch => 'master'
-  gem 'rspec-support', :github => 'rspec/rspec-support', :branch => 'master'
-  gem 'rspec-expectations', :github => 'rspec/rspec-expectations', :branch => 'master'
 end

--- a/Appraisals
+++ b/Appraisals
@@ -1,19 +1,16 @@
 appraise 'rails40' do
   gem 'rails', '~> 4.0.0'
-  gem 'rails-observers'
   gem 'protected_attributes'
   gem 'test-unit'
 end
 
 appraise 'rails41' do
   gem 'rails', '~> 4.1.0'
-  gem 'rails-observers'
   gem 'protected_attributes'
 end
 
 appraise 'rails42' do
   gem 'rails', '~> 4.2.0'
-  gem 'rails-observers'
   gem 'protected_attributes'
 end
 
@@ -21,6 +18,5 @@ appraise 'rails50' do
   gem 'rails', '~> 5.0.0'
 
   # The following needs to point to Github until the release of 0.1.3
-  gem 'rails-observers', :github => 'rails/rails-observers', :branch => 'master'
-
+  gem 'rails-observers', github: 'rails/rails-observers', branch: 'master'
 end

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Audited.current_user_method = :authenticated_user
 Outside of a request, Audited can still record the user with the `as_user` method:
 
 ```ruby
-Audited.audit_class.as_user(User.find(1)) do
+Audited::Audit.as_user(User.find(1)) do
   post.update_attribute!(title: "Hello, world!")
 end
 post.audits.last.user # => #<User id: 1>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 Audited [![Build Status](https://secure.travis-ci.org/collectiveidea/audited.png)](http://travis-ci.org/collectiveidea/audited) [![Dependency Status](https://gemnasium.com/collectiveidea/audited.png)](https://gemnasium.com/collectiveidea/audited)[![Code Climate](https://codeclimate.com/github/collectiveidea/audited.png)](https://codeclimate.com/github/collectiveidea/audited)
 =======
 
-> ## Important version disclaimer
-> ***This README is for a branch which is still in development.
-> Please switch to the [4.2-stable branch](https://github.com/collectiveidea/audited/tree/4.2-stable) for a stable version.***
-
 **Audited** (previously acts_as_audited) is an ORM extension that logs all changes to your models. Audited also allows you to record who made those changes, save comments and associate models related to the changes.
 
 Audited currently (4.x) works with Rails 5.0 and 4.2. It also may work with 4.1 and 4.0, but this is not guaranteed.
@@ -17,7 +13,7 @@ Audited supports and is [tested against](http://travis-ci.org/collectiveidea/aud
 
 * 2.1.5
 * 2.2.4
-* 2.3.0
+* 2.3.1
 
 Audited may work just fine with a Ruby version not listed above, but we can't guarantee that it will. If you'd like to maintain a Ruby that isn't listed, please let us know with a [pull request](https://github.com/collectiveidea/audited/pulls).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Audited is currently ActiveRecord-only. In a previous life, Audited worked with 
 Add the gem to your Gemfile:
 
 ```ruby
-gem "audited", "~> 4.0"
+gem "audited", "~> 4.3"
 ```
 
 If you are using rails 5.0, you would also need the following line in your Gemfile.

--- a/audited.gemspec
+++ b/audited.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'rails', '>= 4.0', '< 5.1'
-  gem.add_development_dependency 'rspec-rails', '~> 3.4'
+  gem.add_development_dependency 'rspec-rails', '~> 3.5'
 
   # JRuby support for the test ENV
   if defined?(JRUBY_VERSION)

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.0.0"
-gem "rails-observers"
 gem "protected_attributes"
 gem "test-unit"
 

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.1.0"
-gem "rails-observers"
 gem "protected_attributes"
 
 gemspec :name => "audited", :path => "../"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
-gem "rails-observers"
 gem "protected_attributes"
 
 gemspec :name => "audited", :path => "../"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -4,10 +4,5 @@ source "https://rubygems.org"
 
 gem "rails", ">= 5.0.0.alpha", "< 5.1"
 gem "rails-observers", :github => "rails/rails-observers", :branch => "master"
-gem "rspec-core", :github => "rspec/rspec-core", :branch => "master"
-gem "rspec-rails", :github => "rspec/rspec-rails", :branch => "master"
-gem "rspec-mocks", :github => "rspec/rspec-mocks", :branch => "master"
-gem "rspec-support", :github => "rspec/rspec-support", :branch => "master"
-gem "rspec-expectations", :github => "rspec/rspec-expectations", :branch => "master"
 
 gemspec :name => "audited", :path => "../"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", ">= 5.0.0.alpha", "< 5.1"
+gem "rails", "~> 5.0.0"
 gem "rails-observers", :github => "rails/rails-observers", :branch => "master"
 
 gemspec :name => "audited", :path => "../"

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -3,7 +3,13 @@ require 'active_record'
 
 module Audited
   class << self
-    attr_accessor :ignored_attributes, :current_user_method, :audit_class
+    attr_accessor :ignored_attributes, :current_user_method
+
+    # Deprecate audit_class accessors in preperation of their removal
+    def audit_class
+      Audited::Audit
+    end
+    deprecate audit_class: "Audited.audit_class is now always Audited::Audit. This method will be removed."
 
     def store
       Thread.current[:audited_store] ||= {}
@@ -19,7 +25,5 @@ require 'audited/auditor'
 require 'audited/audit'
 
 ::ActiveRecord::Base.send :include, Audited::Auditor
-
-Audited.audit_class = Audited::Audit
 
 require 'audited/sweeper'

--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -32,10 +32,10 @@ module Audited
     scope :updates,       ->{ where(action: 'update')}
     scope :destroys,      ->{ where(action: 'destroy')}
 
-    scope :up_until,      ->(date_or_time){where("created_at <= ?", date_or_time) }
-    scope :from_version,  ->(version){where(['version >= ?', version]) }
-    scope :to_version,    ->(version){where(['version <= ?', version]) }
-    scope :auditable_finder, ->(auditable_id, auditable_type){where(auditable_id: auditable_id, auditable_type: auditable_type)}
+    scope :up_until,      ->(date_or_time){ where("created_at <= ?", date_or_time) }
+    scope :from_version,  ->(version){ where('version >= ?', version) }
+    scope :to_version,    ->(version){ where('version <= ?', version) }
+    scope :auditable_finder, ->(auditable_id, auditable_type){ where(auditable_id: auditable_id, auditable_type: auditable_type)}
     # Return all audits older than the current one.
     def ancestors
       self.class.ascending.auditable_finder(auditable_id, auditable_type).to_version(version)

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -59,8 +59,8 @@ module Audited
 
         attr_accessor :audit_comment
 
-        has_many :audits, -> { order(version: :asc) }, as: :auditable, class_name: Audited.audit_class.name
-        Audited.audit_class.audited_class_names << to_s
+        has_many :audits, -> { order(version: :asc) }, as: :auditable, class_name: Audit.name
+        Audit.audited_class_names << to_s
 
         after_create :audit_create if !options[:on] || (options[:on] && options[:on].include?(:create))
         before_update :audit_update if !options[:on] || (options[:on] && options[:on].include?(:update))
@@ -82,7 +82,7 @@ module Audited
       end
 
       def has_associated_audits
-        has_many :associated_audits, as: :associated, class_name: Audited.audit_class.name
+        has_many :associated_audits, as: :associated, class_name: Audit.name
       end
 
       def default_ignored_attributes
@@ -125,13 +125,13 @@ module Audited
 
       # Get a specific revision specified by the version number, or +:previous+
       def revision(version)
-        revision_with Audited.audit_class.reconstruct_attributes(audits_to(version))
+        revision_with Audit.reconstruct_attributes(audits_to(version))
       end
 
       # Find the oldest revision recorded prior to the date/time provided.
       def revision_at(date_or_time)
         audits = self.audits.up_until(date_or_time)
-        revision_with Audited.audit_class.reconstruct_attributes(audits) unless audits.empty?
+        revision_with Audit.reconstruct_attributes(audits) unless audits.empty?
       end
 
       # List of attributes that are audited.
@@ -155,7 +155,7 @@ module Audited
           revision.send :instance_variable_set, '@destroyed', false
           revision.send :instance_variable_set, '@_destroyed', false
           revision.send :instance_variable_set, '@marked_for_destruction', false
-          Audited.audit_class.assign_revision_attributes(revision, attributes)
+          Audit.assign_revision_attributes(revision, attributes)
 
           # Remove any association proxies so that they will be recreated
           # and reference the correct object for this revision. The only way
@@ -281,7 +281,7 @@ module Audited
       # convenience wrapper around
       # @see Audit#as_user.
       def audit_as(user, &block)
-        Audited.audit_class.as_user(user, &block)
+        Audit.as_user(user, &block)
       end
 
       def auditing_enabled

--- a/lib/audited/rspec_matchers.rb
+++ b/lib/audited/rspec_matchers.rb
@@ -170,7 +170,7 @@ module Audited
       def association_exists?
         !reflection.nil? &&
           reflection.macro == :has_many &&
-          reflection.options[:class_name] == Audited.audit_class.name
+          reflection.options[:class_name] == Audit.name
       end
     end
   end

--- a/lib/audited/sweeper.rb
+++ b/lib/audited/sweeper.rb
@@ -3,7 +3,7 @@ require "rails/observers/action_controller/caching"
 
 module Audited
   class Sweeper < ActionController::Caching::Sweeper
-    observe Audited.audit_class
+    observe Audited::Audit
 
     def around(controller)
       begin
@@ -54,9 +54,9 @@ end
 
 ActiveSupport.on_load(:action_controller) do
   if defined?(ActionController::Base)
-    ActionController::Base.around_action Audited::Sweeper.instance 
+    ActionController::Base.around_action Audited::Sweeper.instance
   end
   if defined?(ActionController::API)
-    ActionController::API.around_action Audited::Sweeper.instance 
+    ActionController::API.around_action Audited::Sweeper.instance
   end
 end

--- a/lib/audited/sweeper.rb
+++ b/lib/audited/sweeper.rb
@@ -6,12 +6,10 @@ module Audited
     observe Audited::Audit
 
     def around(controller)
-      begin
-        self.controller = controller
-        yield
-      ensure
-        self.controller = nil
-      end
+      self.controller = controller
+      yield
+    ensure
+      self.controller = nil
     end
 
     def before_create(audit)

--- a/lib/audited/version.rb
+++ b/lib/audited/version.rb
@@ -1,3 +1,3 @@
 module Audited
-  VERSION = "4.2.0"
+  VERSION = "4.3.0"
 end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -57,7 +57,7 @@ describe Audited::Auditor do
     it "should change the audit count" do
       expect {
         user
-      }.to change( Audited.audit_class, :count ).by(1)
+      }.to change( Audited::Audit, :count ).by(1)
     end
 
     it "should create associated audit" do
@@ -66,7 +66,7 @@ describe Audited::Auditor do
 
     it "should set the action to create" do
       expect(user.audits.first.action).to eq('create')
-      expect(Audited.audit_class.creates.order(:id).last).to eq(user.audits.first)
+      expect(Audited::Audit.creates.order(:id).last).to eq(user.audits.first)
       expect(user.audits.creates.count).to eq(1)
       expect(user.audits.updates.count).to eq(0)
       expect(user.audits.destroys.count).to eq(0)
@@ -88,7 +88,7 @@ describe Audited::Auditor do
     it "should not save an audit if only specified on update/destroy" do
       expect {
         Models::ActiveRecord::OnUpdateDestroy.create!( :name => 'Bart' )
-      }.to_not change( Audited.audit_class, :count )
+      }.to_not change( Audited::Audit, :count )
     end
   end
 
@@ -100,16 +100,16 @@ describe Audited::Auditor do
     it "should save an audit" do
       expect {
         @user.update_attribute(:name, "Someone")
-      }.to change( Audited.audit_class, :count ).by(1)
+      }.to change( Audited::Audit, :count ).by(1)
       expect {
         @user.update_attribute(:name, "Someone else")
-      }.to change( Audited.audit_class, :count ).by(1)
+      }.to change( Audited::Audit, :count ).by(1)
     end
 
     it "should set the action to 'update'" do
       @user.update_attributes :name => 'Changed'
       expect(@user.audits.last.action).to eq('update')
-      expect(Audited.audit_class.updates.order(:id).last).to eq(@user.audits.last)
+      expect(Audited::Audit.updates.order(:id).last).to eq(@user.audits.last)
       expect(@user.audits.updates.last).to eq(@user.audits.last)
     end
 
@@ -126,28 +126,28 @@ describe Audited::Auditor do
       on_create_destroy = Models::ActiveRecord::OnCreateDestroy.create( :name => 'Bart' )
       expect {
         on_create_destroy.update_attributes :name => 'Changed'
-      }.to_not change( Audited.audit_class, :count )
+      }.to_not change( Audited::Audit, :count )
     end
 
     it "should not save an audit if the value doesn't change after type casting" do
       @user.update_attributes! :logins => 0, :activated => true
-      expect { @user.update_attribute :logins, '0' }.to_not change( Audited.audit_class, :count )
-      expect { @user.update_attribute :activated, 1 }.to_not change( Audited.audit_class, :count )
-      expect { @user.update_attribute :activated, '1' }.to_not change( Audited.audit_class, :count )
+      expect { @user.update_attribute :logins, '0' }.to_not change( Audited::Audit, :count )
+      expect { @user.update_attribute :activated, 1 }.to_not change( Audited::Audit, :count )
+      expect { @user.update_attribute :activated, '1' }.to_not change( Audited::Audit, :count )
     end
 
     describe "with no dirty changes" do
       it "does not create an audit if the record is not changed" do
         expect {
           @user.save!
-        }.to_not change( Audited.audit_class, :count )
+        }.to_not change( Audited::Audit, :count )
       end
 
       it "creates an audit when an audit comment is present" do
         expect {
           @user.audit_comment = "Comment"
           @user.save!
-        }.to change( Audited.audit_class, :count )
+        }.to change( Audited::Audit, :count )
       end
     end
   end
@@ -160,7 +160,7 @@ describe Audited::Auditor do
     it "should save an audit" do
       expect {
         @user.destroy
-      }.to change( Audited.audit_class, :count )
+      }.to change( Audited::Audit, :count )
 
       expect(@user.audits.size).to eq(2)
     end
@@ -169,7 +169,7 @@ describe Audited::Auditor do
       @user.destroy
 
       expect(@user.audits.last.action).to eq('destroy')
-      expect(Audited.audit_class.destroys.order(:id).last).to eq(@user.audits.last)
+      expect(Audited::Audit.destroys.order(:id).last).to eq(@user.audits.last)
       expect(@user.audits.destroys.last).to eq(@user.audits.last)
     end
 
@@ -192,7 +192,7 @@ describe Audited::Auditor do
 
       expect {
         on_create_update.destroy
-      }.to_not change( Audited.audit_class, :count )
+      }.to_not change( Audited::Audit, :count )
     end
 
     it "should audit dependent destructions" do
@@ -201,7 +201,7 @@ describe Audited::Auditor do
 
       expect {
         owner.destroy
-      }.to change( Audited.audit_class, :count )
+      }.to change( Audited::Audit, :count )
 
       expect(company.audits.map { |a| a.action }).to eq(['create', 'destroy'])
     end
@@ -413,13 +413,13 @@ describe Audited::Auditor do
       expect {
         u = Models::ActiveRecord::User.new(:name => 'Brandon')
         expect(u.save_without_auditing).to eq(true)
-      }.to_not change( Audited.audit_class, :count )
+      }.to_not change( Audited::Audit, :count )
     end
 
     it "should not save an audit inside of the #without_auditing block" do
       expect {
         Models::ActiveRecord::User.without_auditing { Models::ActiveRecord::User.create!( :name => 'Brandon' ) }
-      }.to_not change( Audited.audit_class, :count )
+      }.to_not change( Audited::Audit, :count )
     end
 
     it "should reset auditing status even it raises an exception" do

--- a/spec/audited/sweeper_spec.rb
+++ b/spec/audited/sweeper_spec.rb
@@ -34,7 +34,7 @@ describe AuditsController do
       controller.send(:current_user=, user)
       expect {
         post :audit
-      }.to change( Audited.audit_class, :count )
+      }.to change( Audited::Audit, :count )
 
       expect(controller.company.audits.last.user).to eq(user)
     end
@@ -45,7 +45,7 @@ describe AuditsController do
 
       expect {
         post :audit
-      }.to change( Audited.audit_class, :count )
+      }.to change( Audited::Audit, :count )
 
       expect(controller.company.audits.last.user).to eq(user)
     end
@@ -77,7 +77,7 @@ describe AuditsController do
 
       expect {
         post :update_user
-      }.to_not change( Audited.audit_class, :count )
+      }.to_not change( Audited::Audit, :count )
     end
 
   end

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -1,6 +1,3 @@
 Rails.application.routes.draw do
-
-  # This is a legacy wild controller route that's not recommended for RESTful applications.
-  # Note: This route will make all actions in every controller accessible via GET requests.
-  match ':controller(/:action(/:id(.:format)))', via: [:get, :post, :put, :delete]
+  resources :audits
 end

--- a/test/install_generator_test.rb
+++ b/test/install_generator_test.rb
@@ -11,7 +11,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator %w(install)
 
     assert_migration "db/migrate/install_audited.rb" do |content|
-      assert_match /class InstallAudited/, content
+      assert_match(/class InstallAudited/, content)
     end
   end
 end

--- a/test/upgrade_generator_test.rb
+++ b/test/upgrade_generator_test.rb
@@ -14,7 +14,7 @@ class UpgradeGeneratorTest < Rails::Generators::TestCase
     run_generator %w(upgrade)
 
     assert_migration "db/migrate/add_comment_to_audits.rb" do |content|
-      assert_match /add_column :audits, :comment, :string/, content
+      assert_match(/add_column :audits, :comment, :string/, content)
     end
 
     assert_migration "db/migrate/rename_changes_to_audited_changes.rb"
@@ -28,7 +28,7 @@ class UpgradeGeneratorTest < Rails::Generators::TestCase
     assert_no_migration "db/migrate/add_comment_to_audits.rb"
 
     assert_migration "db/migrate/rename_changes_to_audited_changes.rb" do |content|
-      assert_match /rename_column :audits, :changes, :audited_changes/, content
+      assert_match(/rename_column :audits, :changes, :audited_changes/, content)
     end
   end
 
@@ -38,7 +38,7 @@ class UpgradeGeneratorTest < Rails::Generators::TestCase
     run_generator %w(upgrade)
 
     assert_migration "db/migrate/add_remote_address_to_audits.rb" do |content|
-      assert_match /add_column :audits, :remote_address, :string/, content
+      assert_match(/add_column :audits, :remote_address, :string/, content)
     end
   end
 
@@ -48,8 +48,8 @@ class UpgradeGeneratorTest < Rails::Generators::TestCase
     run_generator %w(upgrade)
 
     assert_migration "db/migrate/add_association_to_audits.rb" do |content|
-      assert_match /add_column :audits, :association_id, :integer/, content
-      assert_match /add_column :audits, :association_type, :string/, content
+      assert_match(/add_column :audits, :association_id, :integer/, content)
+      assert_match(/add_column :audits, :association_type, :string/, content)
     end
   end
 
@@ -59,8 +59,8 @@ class UpgradeGeneratorTest < Rails::Generators::TestCase
     run_generator %w(upgrade)
 
     assert_migration "db/migrate/rename_association_to_associated.rb" do |content|
-      assert_match /rename_column :audits, :association_id, :associated_id/, content
-      assert_match /rename_column :audits, :association_type, :associated_type/, content
+      assert_match(/rename_column :audits, :association_id, :associated_id/, content)
+      assert_match(/rename_column :audits, :association_type, :associated_type/, content)
     end
   end
 
@@ -70,8 +70,8 @@ class UpgradeGeneratorTest < Rails::Generators::TestCase
     run_generator %w(upgrade)
 
     assert_migration "db/migrate/add_request_uuid_to_audits.rb" do |content|
-      assert_match /add_column :audits, :request_uuid, :string/, content
-      assert_match /add_index :audits, :request_uuid/, content
+      assert_match(/add_column :audits, :request_uuid, :string/, content)
+      assert_match(/add_index :audits, :request_uuid/, content)
     end
   end
 end


### PR DESCRIPTION
Prepping for a new version (4.3.0) since Rails 5 is final. 

Mostly testing and README changes.

Still need: 

- [ ] [rails-observers](https://rubygems.org/gems/rails-observers) gem needs to release a new version to support Rails 5. In the meantime, you can point to the github repo.