### PR TITLE
Fixed README to avoid conflicts in rails 5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Add the gem to your Gemfile:
 gem "audited", "~> 4.0"
 ```
 
+If you are using rails 5.0, you would also need the following line in your Gemfile.
+```ruby
+gem "rails-observers", github: 'rails/rails-observers'
+```
+
 Then, from your Rails app directory, create the `audits` table:
 
 ```bash


### PR DESCRIPTION
If you follow instructions in the README, you'll end up with:
```
Bundler could not find compatible versions for gem "activemodel":
.....
    audited was resolved to 4.2.0, which depends on
      rails-observers (~> 0.1.2) was resolved to 0.1.2, which depends on
        activemodel (~> 4.0)
....
```
This appears to be because rails-observers doesn't resolve to 0.1.3.alpha (presumably because it is alpha?).