### PR TITLE
Correct auditing_enabled for STI models

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -285,11 +285,11 @@ module Audited
       end
 
       def auditing_enabled
-        Audited.store.fetch("#{name.tableize}_auditing_enabled", true)
+        Audited.store.fetch("#{self.table_name}_auditing_enabled", true)
       end
 
       def auditing_enabled= val
-        Audited.store["#{name.tableize}_auditing_enabled"] = val
+        Audited.store["#{self.table_name}_auditing_enabled"] = val
       end
     end
   end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -573,4 +573,16 @@ describe Audited::Auditor do
       expect(user.around_attr).to eq(user.audits.last)
     end
   end
+
+  describe "STI auditing" do
+    it "should correctly disable auditing when using STI" do
+      company = Models::ActiveRecord::Company::STICompany.create :name => 'The auditors'
+      expect(company.type).to eq("Models::ActiveRecord::Company::STICompany")
+      expect {
+        Models::ActiveRecord::Company.auditing_enabled = false
+        company.update_attributes :name => 'STI auditors'
+        Models::ActiveRecord::Company.auditing_enabled = true
+      }.to_not change( Audited.audit_class, :count )
+    end
+  end
 end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -53,6 +53,9 @@ module Models
       audited
     end
 
+    class Company::STICompany < Company
+    end
+
     class Owner < ::ActiveRecord::Base
       self.table_name = 'users'
       has_associated_audits

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -11,8 +11,8 @@ begin
     db_file.unlink if db_file.file?
   else
     if defined?(JRUBY_VERSION)
-      db_config.symbolize_keys! 
-      db_config[:configure_connection] = false 
+      db_config.symbolize_keys!
+      db_config[:configure_connection] = false
     end
     adapter = ActiveRecord::Base.send("#{db_type}_connection", db_config)
     adapter.recreate_database db_name
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define do
   create_table :companies do |t|
     t.column :name, :string
     t.column :owner_id, :integer
+    t.column :type, :string
   end
 
   create_table :authors do |t|


### PR DESCRIPTION
The store used for setting and checking auditing_enabled uses
`name.tableize`, which causes STI models to check the incorrect key - if
auditing is disabled on the parent, children should also not be audited.