### PR TITLE
Optional asynchronous audit creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ User.auditing_enabled = false
 ### Asynchronous Auditing
 
 Generating a lot of auditing data can slow down an application, as it must
-wait for auditing data to be saved to a database before continuing. Moving
-the audit record creation to an asynchronous process such as a background
-job queue frees up your application to continue working without waiting.
+wait for the to be saved to a database before continuing. Moving the audit
+record creation to an asynchronous process such as a background job queue
+frees up your application to continue working without waiting.
 
 To create audit records asynchronously, you need to tell Audited which
 adapter to use by setting `Audited.async_class`. Here is an example

--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ User.auditing_enabled = false
 
 ### Asynchronous Auditing
 
+Generating a lot of auditing data can slow down an application, as it must
+wait for auditing data to be saved to a database before continuing. Moving
+the audit record creation to an asynchronous process such as a background
+job queue frees up your application to continue working without waiting.
+
 To create audit records asynchronously, you need to tell Audited which
 adapter to use by setting `Audited.async_class`. Here is an example
 `config/initializers/audited.rb`:
@@ -292,6 +297,13 @@ processing.
 
 If the adapter raises an error when trying to enqueue audits, the audits are
 written synchronously instead.
+
+One disadvantage to an asynchronous approach is that the `created_at` time
+stamps of the audit records will reflect when the audit records were written
+by the background job, which is not as close to the time of the original
+action that created the audit. It would be relatively easy to modify the
+audited gem so that it passed in the current time when it passed the
+attributes to the background job (see `Audited::Auditor#async_write_audit`).
 
 #### Creating an Async Adapter
 

--- a/README.md
+++ b/README.md
@@ -298,13 +298,6 @@ processing.
 If the adapter raises an error when trying to enqueue audits, the audits are
 written synchronously instead.
 
-One disadvantage to an asynchronous approach is that the `created_at` time
-stamps of the audit records will reflect when the audit records were written
-by the background job, which is not as close to the time of the original
-action that created the audit. It would be relatively easy to modify the
-audited gem so that it passed in the current time when it passed the
-attributes to the background job (see `Audited::Auditor#async_write_audit`).
-
 #### Creating an Async Adapter
 
 Each Audited::Async adapter must implemented an `enqueue` class method that

--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ User.auditing_enabled = false
 ### Asynchronous Auditing
 
 Generating a lot of auditing data can slow down an application, as it must
-wait for the to be saved to a database before continuing. Moving the audit
-record creation to an asynchronous process such as a background job queue
-frees up your application to continue working without waiting.
+wait for the data to be saved to a database before continuing. Moving the
+audit record creation to an asynchronous process such as a background job
+queue frees up your application to continue working without waiting.
 
 To create audit records asynchronously, you need to tell Audited which
 adapter to use by setting `Audited.async_class`. Here is an example

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -3,7 +3,8 @@ require 'active_record'
 
 module Audited
   class << self
-    attr_accessor :ignored_attributes, :current_user_method, :audit_class
+    attr_accessor :ignored_attributes, :current_user_method, :audit_class,
+                  :async_class
 
     def store
       Thread.current[:audited_store] ||= {}
@@ -17,6 +18,7 @@ end
 
 require 'audited/auditor'
 require 'audited/audit'
+require 'audited/async'
 
 ::ActiveRecord::Base.send :include, Audited::Auditor
 

--- a/lib/audited/async.rb
+++ b/lib/audited/async.rb
@@ -1,0 +1,7 @@
+module Audited
+  module Async
+    extend ActiveSupport::Autoload
+    autoload :Resque
+    autoload :Synchronous
+  end
+end

--- a/lib/audited/async/resque.rb
+++ b/lib/audited/async/resque.rb
@@ -1,0 +1,25 @@
+module Audited
+  module Async
+    class Resque
+      @queue = :audit
+
+      # Allow override in initializer
+      def self.queue=(queue)
+        @queue = queue.to_sym
+      end
+
+      def self.enqueue(klass_name, audits_attrs)
+        Resque.enqueue(self, klass_name, audits_attrs)
+      end
+
+      # Takes a model `klass` and an array of hashes of audit `attrs` and
+      # creates audit records from them.
+      def self.perform(klass_name, audits_attrs)
+        klass = Module.const_get(klass_name)
+        audits_attrs.each do |attrs|
+          klass.create(attrs)
+        end
+      end
+    end
+  end
+end

--- a/lib/audited/async/resque.rb
+++ b/lib/audited/async/resque.rb
@@ -9,7 +9,7 @@ module Audited
       end
 
       def self.enqueue(klass_name, audits_attrs)
-        Resque.enqueue(self, klass_name, audits_attrs)
+        ::Resque.enqueue(self, klass_name, audits_attrs)
       end
 
       # Takes a model `klass` and an array of hashes of audit `attrs` and

--- a/lib/audited/async/synchronous.rb
+++ b/lib/audited/async/synchronous.rb
@@ -1,0 +1,15 @@
+require 'audited/audit'
+
+# Only useful for testing.
+module Audited
+  module Async
+    class Synchronous
+      def self.enqueue(klass, audits_attrs)
+        klass = Module.const_get(klass_name)
+        audits_attrs.each do |attrs|
+          klass.create(attrs)
+        end
+      end
+    end
+  end
+end

--- a/lib/audited/async/synchronous.rb
+++ b/lib/audited/async/synchronous.rb
@@ -4,7 +4,7 @@ require 'audited/audit'
 module Audited
   module Async
     class Synchronous
-      def self.enqueue(klass, audits_attrs)
+      def self.enqueue(klass_name, audits_attrs)
         klass = Module.const_get(klass_name)
         audits_attrs.each do |attrs|
           klass.create(attrs)

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -305,6 +305,7 @@ module Audited
           attrs[:user_id] = user.id
           attrs[:user_type] = user.class.name
         end
+        attrs[:created_at] = Time.now
         Thread.current[self.class.batched_audit_attrs_sym] << attrs
       end
 

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -284,7 +284,7 @@ module Audited
         if self.async_enabled
           async_write_audit(attrs)
         else
-          run_callbacks(:audit)  { self.audits.create!(attrs) }
+          run_callbacks(:audit) { self.audits.create(attrs) } if auditing_enabled
         end
       end
 

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -38,10 +38,10 @@ module Audited
       #   audit records.
       #
       #     class User < ActiveRecord::Base
-      #       audited async: :resque
+      #       audited async: true
       #     end
       #
-      #   Only Resque is implemented now.
+      #   See the README for details.
       #
       #   While audits are being triggered by Audited callbacks, the
       #   attributes needed to create the audit are saved in class instance
@@ -49,7 +49,7 @@ module Audited
       #   are sent to an asynchronous job so the audit records can be
       #   created.
       #
-      #   Wyen creating audits asynchronously, if a transaction fails the
+      #   When creating audits asynchronously, if a transaction fails the
       #   `after_commit` callback will never get run so all of the audits
       #   will be ignored. This is what we want.
       #

--- a/lib/audited/rspec_matchers.rb
+++ b/lib/audited/rspec_matchers.rb
@@ -84,6 +84,7 @@ module Audited
         description += " only => #{@options[:only].join ', '}"          if @options.key?(:only)
         description += " except => #{@options[:except].join(', ')}"     if @options.key?(:except)
         description += " requires audit_comment"                        if @options.key?(:comment_required)
+        description += " async"                                         if @options.key?(:async)
 
         description
       end
@@ -97,6 +98,11 @@ module Audited
       def auditing_enabled?
         expects "#{model_class} to be audited"
         model_class.respond_to?(:auditing_enabled) && model_class.auditing_enabled
+      end
+
+      def async_enabled?
+        expects "#{model_class} to be async"
+        model_class.respond_to?(:async_enabled) && model_class.async_enabled
       end
 
       def model_class

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -606,10 +606,6 @@ describe Audited::Auditor do
       expect(owned_company.async_enabled).to be_truthy
     end
 
-    it "should have a class attribute that can store attrs" do
-      expect(Thread.current[owned_company.class.batched_audit_attrs_sym]).to eq []
-    end
-
     it "should enqueue the job" do
       expect(Audited::Async::Synchronous)
         .to receive(:enqueue)
@@ -659,7 +655,7 @@ describe Audited::Auditor do
 
     it "should empty the class variable after saving" do
       owned_company.save
-      expect(Thread.current[owned_company.class.batched_audit_attrs_sym]).to be_empty
+      expect(Thread.current[owned_company.class.batched_audit_attrs_sym]).to be_nil
     end
 
     it "should write synchronously on async error" do

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -620,7 +620,8 @@ describe Audited::Auditor do
                       auditable_type: owned_company.class.name,
                       auditable_id: anything,
                       associated_type: owner.class.name,
-                      associated_id: owner.id}])
+                      associated_id: owner.id,
+                      created_at: anything}])
       owned_company.save
     end
 

--- a/spec/rails_app/config/environments/test.rb
+++ b/spec/rails_app/config/environments/test.rb
@@ -44,4 +44,13 @@ RailsApp::Application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # DEPRECATION WARNING: Currently, Active Record suppresses errors raised
+  # within `after_rollback`/`after_commit` callbacks and only print them to
+  # the logs. In the next version, these errors will no longer be
+  # suppressed. Instead, the errors will propagate normally just like in
+  # other Active Record callbacks.
+  #
+  # You can opt into the new behavior and remove this warning by setting:
+  config.active_record.raise_in_transactional_callbacks = true
 end

--- a/spec/rails_app/config/environments/test.rb
+++ b/spec/rails_app/config/environments/test.rb
@@ -52,5 +52,7 @@ RailsApp::Application.configure do
   # other Active Record callbacks.
   #
   # You can opt into the new behavior and remove this warning by setting:
-  config.active_record.raise_in_transactional_callbacks = true
+  if Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR >= 2
+    config.active_record.raise_in_transactional_callbacks = true
+  end
 end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -88,5 +88,13 @@ module Models
       self.table_name = 'companies'
       audited on: [:create, :update]
     end
+
+    class AsyncOwnedCompanyRequired < ::ActiveRecord::Base
+      self.table_name = 'companies'
+      belongs_to :owner, class_name: "Owner"
+      validates_presence_of :owner
+      attr_accessible :name, :owner if respond_to?(:attr_accessible) # declare attr_accessible before calling aaa
+      audited associated_with: :owner, async: true
+    end
   end
 end


### PR DESCRIPTION
Adds the option to create audit records asynchronously using a queueing framework such as Resque. See the new sections in the README: "Asynchronous Auditing" and those following it.
