### PR TITLE
Fix auditing instance attributes if "only" option specified

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -175,7 +175,15 @@ module Audited
       private
 
       def audited_changes
-        changed_attributes.except(*non_audited_columns).inject({}) do |changes, (attr, old_value)|
+        collection =
+          if audited_options[:only]
+            audited_columns = self.class.audited_columns.map(&:name)
+            changed_attributes.slice(*audited_columns)
+          else
+            changed_attributes.except(*non_audited_columns)
+          end
+
+        collection.inject({}) do |changes, (attr, old_value)|
           changes[attr] = [old_value, self[attr]]
           changes
         end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -29,6 +29,25 @@ describe Audited::Auditor do
     it "should not save non-audited columns" do
       expect(create_user.audits.first.audited_changes.keys.any? { |col| ['created_at', 'updated_at', 'password'].include?( col ) }).to eq(false)
     end
+
+    it "should not save other columns than specified in 'only' option" do
+      user = Models::ActiveRecord::UserOnlyPassword.create
+      user.instance_eval do
+        def non_column_attr
+          @non_column_attr
+        end
+
+        def non_column_attr=(val)
+          attribute_will_change!("non_column_attr")
+          @non_column_attr = val
+        end
+      end
+
+      user.password = "password"
+      user.non_column_attr = "some value"
+      user.save!
+      expect(user.audits.last.audited_changes.keys).to eq(%w{password})
+    end
   end
 
   describe :new do

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -13,6 +13,11 @@ module Models
       end
     end
 
+    class UserOnlyPassword < ::ActiveRecord::Base
+      self.table_name = :users
+      audited allow_mass_assignment: true, only: [:password]
+    end
+
     class CommentRequiredUser < ::ActiveRecord::Base
       self.table_name = :users
       audited comment_required: true


### PR DESCRIPTION
Currently it's possible to add non-column attribute and it will be audited even though we have `only` options specified.
The problem is that we rely on `ActiveModel::Dirty#changed_attributes` which records non-column attributes but we excludes column attributes only.

This PR adds a test case and working solution.