### PR TITLE
Allow to pass both singular value and array to `:only` option

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -259,7 +259,7 @@ module Audited
         @non_audited_columns ||= begin
           options = audited_options
           if options[:only]
-            except = self.column_names - options[:only].flatten.map(&:to_s)
+            except = self.column_names - Array.wrap(options[:only]).flatten.map(&:to_s)
           else
             except = default_ignored_attributes + Audited.ignored_attributes
             except |= Array(options[:except]).collect(&:to_s) if options[:except]

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -15,7 +15,7 @@ module Models
 
     class UserOnlyPassword < ::ActiveRecord::Base
       self.table_name = :users
-      audited allow_mass_assignment: true, only: [:password]
+      audited allow_mass_assignment: true, only: :password
     end
 
     class CommentRequiredUser < ::ActiveRecord::Base


### PR DESCRIPTION
Allow to pass both singular value and array to `:only` option

```ruby
class SomethingAudited < ActiveRecord::Base
  audit only: :password

  # would previously have required
  # audit only: [:password]
end
```

Similar to https://github.com/collectiveidea/audited/commit/f62b770b23dd709a1728f9ff00d1d399d73f7fa0