### PR TITLE
Set created_at as collection cache key

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -125,6 +125,11 @@ module Audited
       record
     end
 
+    # use created_at as timestamp cache key
+    def self.collection_cache_key(collection = all, timestamp_column = :created_at)
+      super(collection, :created_at)
+    end
+
     private
 
     def set_version_number


### PR DESCRIPTION
With Rails Conditional GET support (304 caching), the `stale?` and `fresh_when` methods rely on `collection_cache_key`, which by default utilize the `updated_at` column.  Because the audits table doesn't include an `updated_at` column, this throws an SQL error.

This change simply changed the default and relies on `super`.