### PR TITLE
`json` and `jsonb` as possible `audited_changes` column type, fix #216

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   - DB=SQLITE
   - DB=POSTGRES
   - DB=MYSQL
+addons:
+  postgresql: "9.4"
 gemfile:
   - gemfiles/rails40.gemfile
   - gemfiles/rails41.gemfile

--- a/lib/generators/audited/install_generator.rb
+++ b/lib/generators/audited/install_generator.rb
@@ -10,6 +10,8 @@ module Audited
       include Rails::Generators::Migration
       extend Audited::Generators::Migration
 
+      class_option :audited_changes_column_type, type: :string, default: "text", required: false
+
       source_root File.expand_path("../templates", __FILE__)
 
       def copy_migration

--- a/lib/generators/audited/templates/install.rb
+++ b/lib/generators/audited/templates/install.rb
@@ -9,7 +9,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
       t.column :user_type, :string
       t.column :username, :string
       t.column :action, :string
-      t.column :audited_changes, :text
+      t.column :audited_changes, :<%= options[:audited_changes_column_type] %>
       t.column :version, :integer, :default => 0
       t.column :comment, :string
       t.column :remote_address, :string

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -195,5 +195,4 @@ describe Audited::Audit do
     end
 
   end
-
 end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -48,6 +48,38 @@ describe Audited::Auditor do
       user.save!
       expect(user.audits.last.audited_changes.keys).to eq(%w{password})
     end
+
+    if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL' && Rails.version >= "4.2.0.0" # Postgres json and jsonb support was added in Rails 4.2
+      describe "'json' and 'jsonb' audited_changes column type" do
+        let(:migrations_path) { SPEC_ROOT.join("support/active_record/postgres") }
+
+        after do
+          ActiveRecord::Migrator.rollback([migrations_path])
+        end
+
+        it "should work if column type is 'json'" do
+          ActiveRecord::Migrator.up([migrations_path], 1)
+          Audited::Audit.reset_column_information
+          expect(Audited::Audit.columns_hash["audited_changes"].sql_type).to eq("json")
+
+          user = Models::ActiveRecord::User.create
+          user.name = "new name"
+          user.save!
+          expect(user.audits.last.audited_changes).to eq({"name" => [nil, "new name"]})
+        end
+
+        it "should work if column type is 'jsonb'" do
+          ActiveRecord::Migrator.up([migrations_path], 2)
+          Audited::Audit.reset_column_information
+          expect(Audited::Audit.columns_hash["audited_changes"].sql_type).to eq("jsonb")
+
+          user = Models::ActiveRecord::User.create
+          user.name = "new name"
+          user.save!
+          expect(user.audits.last.audited_changes).to eq({"name" => [nil, "new name"]})
+        end
+      end
+    end
   end
 
   describe :new do
@@ -601,7 +633,7 @@ describe Audited::Auditor do
         Models::ActiveRecord::Company.auditing_enabled = false
         company.update_attributes name: 'STI auditors'
         Models::ActiveRecord::Company.auditing_enabled = true
-      }.to_not change( Audited.audit_class, :count )
+      }.to_not change( Audited::Audit, :count )
     end
   end
 end

--- a/spec/support/active_record/postgres/1_change_audited_changes_type_to_json.rb
+++ b/spec/support/active_record/postgres/1_change_audited_changes_type_to_json.rb
@@ -1,0 +1,11 @@
+class ChangeAuditedChangesTypeToJson < ActiveRecord::Migration
+  def self.up
+    remove_column :audits, :audited_changes
+    add_column :audits, :audited_changes, :json
+  end
+
+  def self.down
+    remove_column :audits, :audited_changes
+    add_column :audits, :audited_changes, :text
+  end
+end

--- a/spec/support/active_record/postgres/2_change_audited_changes_type_to_jsonb.rb
+++ b/spec/support/active_record/postgres/2_change_audited_changes_type_to_jsonb.rb
@@ -1,0 +1,11 @@
+class ChangeAuditedChangesTypeToJsonb < ActiveRecord::Migration
+  def self.up
+    remove_column :audits, :audited_changes
+    add_column :audits, :audited_changes, :jsonb
+  end
+
+  def self.down
+    remove_column :audits, :audited_changes
+    add_column :audits, :audited_changes, :text
+  end
+end

--- a/test/install_generator_test.rb
+++ b/test/install_generator_test.rb
@@ -7,11 +7,30 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   setup :prepare_destination
   tests Audited::Generators::InstallGenerator
 
-  test "should generate a migration" do
-    run_generator %w(install)
+  test "generate migration with 'text' type for audited_changes column" do
+    run_generator
 
     assert_migration "db/migrate/install_audited.rb" do |content|
-      assert_match(/class InstallAudited/, content)
+      assert_includes(content, 'class InstallAudited')
+      assert_includes(content, 't.column :audited_changes, :text')
+    end
+  end
+
+  test "generate migration with 'jsonb' type for audited_changes column" do
+    run_generator %w(--audited-changes-column-type jsonb)
+
+    assert_migration "db/migrate/install_audited.rb" do |content|
+      assert_includes(content, 'class InstallAudited')
+      assert_includes(content, 't.column :audited_changes, :jsonb')
+    end
+  end
+
+  test "generate migration with 'json' type for audited_changes column" do
+    run_generator %w(--audited-changes-column-type json)
+
+    assert_migration "db/migrate/install_audited.rb" do |content|
+      assert_includes(content, 'class InstallAudited')
+      assert_includes(content, 't.column :audited_changes, :json')
     end
   end
 end


### PR DESCRIPTION
- update migration
- set postgres travis version to 9.4 to allow `jsonb`
