### PR TITLE
rename instance attribute version to audit_version

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -46,7 +46,7 @@ module Audited
     def revision
       clazz = auditable_type.constantize
       (clazz.find_by_id(auditable_id) || clazz.new).tap do |m|
-        self.class.assign_revision_attributes(m, self.class.reconstruct_attributes(ancestors).merge(version: version))
+        self.class.assign_revision_attributes(m, self.class.reconstruct_attributes(ancestors).merge(audit_version: version))
       end
     end
 
@@ -105,7 +105,7 @@ module Audited
     def self.reconstruct_attributes(audits)
       attributes = {}
       result = audits.collect do |audit|
-        attributes.merge!(audit.new_attributes)[:version] = audit.version
+        attributes.merge!(audit.new_attributes)[:audit_version] = audit.version
         yield attributes if block_given?
       end
       block_given? ? result : attributes

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -66,7 +66,7 @@ module Audited
         set_callback :audit, :after, :after_audit, if: lambda { respond_to?(:after_audit, true) }
         set_callback :audit, :around, :around_audit, if: lambda { respond_to?(:around_audit, true) }
 
-        attr_accessor :version
+        attr_accessor :audit_version
 
         extend Audited::Auditor::AuditedClassMethods
         include Audited::Auditor::AuditedInstanceMethods
@@ -191,8 +191,8 @@ module Audited
 
       def audits_to(version = nil)
         if version == :previous
-          version = if self.version
-                      self.version - 1
+          version = if self.audit_version
+                      self.audit_version - 1
                     else
                       previous = audits.descending.offset(1).first
                       previous ? previous.version : 1

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -335,21 +335,21 @@ describe Audited::Auditor do
     it "should find the given revision" do
       revision = user.revision(3)
       expect(revision).to be_a_kind_of( Models::ActiveRecord::User )
-      expect(revision.version).to eq(3)
+      expect(revision.audit_version).to eq(3)
       expect(revision.name).to eq('Foobar 3')
     end
 
     it "should find the previous revision with :previous" do
       revision = user.revision(:previous)
-      expect(revision.version).to eq(4)
+      expect(revision.audit_version).to eq(4)
       #expect(revision).to eq(user.revision(4))
       expect(revision.attributes).to eq(user.revision(4).attributes)
     end
 
     it "should be able to get the previous revision repeatedly" do
       previous = user.revision(:previous)
-      expect(previous.version).to eq(4)
-      expect(previous.revision(:previous).version).to eq(3)
+      expect(previous.audit_version).to eq(4)
+      expect(previous.revision(:previous).audit_version).to eq(3)
     end
 
     it "should be able to set protected attributes" do
@@ -419,7 +419,7 @@ describe Audited::Auditor do
       audit.created_at = 1.hour.ago
       audit.save!
       user.update_attributes name: 'updated'
-      expect(user.revision_at( 2.minutes.ago ).version).to eq(1)
+      expect(user.revision_at( 2.minutes.ago ).audit_version).to eq(1)
     end
 
     it "should be nil if given a time before audits" do


### PR DESCRIPTION
seems dangerous to dynamically add an accessor method called version
because version is such a common name and could lead to some
unexpected behaviour in applications using audited.