### PR TITLE
Adding support for conditional audit writing.

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -219,9 +219,26 @@ module Audited
       end
 
       def write_audit(attrs)
+        return unless should_audit?(attrs)
         attrs[:associated] = send(audit_associated_with) unless audit_associated_with.nil?
         self.audit_comment = nil
         run_callbacks(:audit)  { audits.create(attrs) } if auditing_enabled
+      end
+
+      def should_audit?(attrs)
+        if audited_options[:if]
+          case audited_options[:if]
+          when Proc
+            audited_options[:if].call(self, attrs)
+          when Symbol
+            send(audited_options[:if], attrs)
+          else
+            errors.add(:audit, "Unsupported conditional argument of type #{audited_options[:if].class}")
+            false
+          end
+        else
+          true
+        end
       end
 
       def require_comment
@@ -280,6 +297,7 @@ module Audited
       ensure
         enable_auditing if auditing_was_enabled
       end
+
 
       def disable_auditing
         self.auditing_enabled = false

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -427,6 +427,49 @@ describe Audited::Auditor do
     end
   end
 
+  describe "conditional auditing" do
+    context "by proc" do
+      it "should save an audit when asked to" do
+        expect {
+          u = Models::ActiveRecord::UserIfByProc.new(name: 'Brandon')
+          u.flag = true
+          expect(u.save).to eq(true)
+        }.to change( Audited::Audit, :count ).by(1)
+      end
+      it "should not save an audit when asked not to" do
+        expect {
+          u = Models::ActiveRecord::UserIfByProc.new(name: 'Brandon')
+          u.flag = false
+          expect(u.save).to eq(true)
+        }.to_not change( Audited::Audit, :count )
+      end
+    end
+    context "by symbol" do
+      it "should save an audit when asked to" do
+        expect {
+          u = Models::ActiveRecord::UserIfBySymbol.new(name: 'Brandon')
+          u.flag = true 
+          expect(u.save).to eq(true)
+        }.to change( Audited::Audit, :count ).by(1)
+      end
+      it "should save an audit when asked not to" do
+        expect {
+          u = Models::ActiveRecord::UserIfBySymbol.new(name: 'Brandon')
+          u.flag = false
+          expect(u.save).to eq(true)
+        }.to_not change( Audited::Audit, :count )
+      end
+    end
+    context "by weirdness" do
+      it "should not save, but record should save" do
+        expect {
+          u = Models::ActiveRecord::UserIfByBadness.new(name: 'Brandon')
+          expect(u.save).to eq(true)
+        }.to_not change( Audited::Audit, :count )
+      end
+    end
+  end
+
   describe "without auditing" do
     it "should not save an audit when calling #save_without_auditing" do
       expect {

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -13,6 +13,33 @@ module Models
       end
     end
 
+    class UserIfBySymbol < ::ActiveRecord::Base
+      self.table_name = :users
+      audited allow_mass_assignment: true, if: :audit?
+
+      attr_accessor :flag
+
+      def audit?(attrs)
+        flag
+      end
+    end
+
+    class UserIfByProc < ::ActiveRecord::Base
+      self.table_name = :users
+
+      attr_accessor :flag
+
+      audited allow_mass_assignment: true, if: ->(user, attrs) { user.flag }
+    end
+
+    class UserIfByBadness < ::ActiveRecord::Base
+      self.table_name = :users
+
+      attr_accessor :flag
+
+      audited allow_mass_assignment: true, if: "bad"
+    end
+
     class UserOnlyPassword < ::ActiveRecord::Base
       self.table_name = :users
       audited allow_mass_assignment: true, only: :password


### PR DESCRIPTION
Adds support for an `if:` option to conditionally write audits.

The argument to `if:` is much the same as the argument to a Rails `if:` callback. It can be either:

- A symbol: meaning a method of the same name wants to be called, or
- A proc: which is called directly.