### PR TITLE
Allow update audits only for authenticated user

### DIFF
--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -3,7 +3,7 @@ require 'active_record'
 
 module Audited
   class << self
-    attr_accessor :ignored_attributes, :current_user_method
+    attr_accessor :ignored_attributes, :current_user_method, :only_authenticated_user
 
     # Deprecate audit_class accessors in preperation of their removal
     def audit_class
@@ -19,6 +19,7 @@ module Audited
   @ignored_attributes = %w(lock_version created_at updated_at created_on updated_on)
 
   @current_user_method = :current_user
+  @only_authenticated_user = false
 end
 
 require 'audited/auditor'

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -3,7 +3,7 @@ require 'active_record'
 
 module Audited
   class << self
-    attr_accessor :ignored_attributes, :current_user_method, :only_authenticated_user
+    attr_accessor :ignored_attributes, :current_user_method, :audit_class, :only_authenticated_user
 
     # Deprecate audit_class accessors in preperation of their removal
     def audit_class

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -250,7 +250,11 @@ module Audited
       end
 
       def skip_writing?
-        Audited.only_authenticated_user ? ::Audited.store[:current_controller]&.send(Audited.current_user_method).blank? : false
+        if Audited.only_authenticated_user
+          ::Audited.store[:current_controller] ? ::Audited.store[:current_controller].send(Audited.current_user_method).blank? : nil
+        else
+          false
+        end
       end
     end # InstanceMethods
 

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -219,6 +219,8 @@ module Audited
       end
 
       def write_audit(attrs)
+        return if skip_writing?
+
         attrs[:associated] = send(audit_associated_with) unless audit_associated_with.nil?
         self.audit_comment = nil
         run_callbacks(:audit)  { audits.create(attrs) } if auditing_enabled
@@ -245,6 +247,10 @@ module Audited
 
       def auditing_enabled=(val)
         self.class.auditing_enabled = val
+      end
+
+      def skip_writing?
+        Audited.only_authenticated_user ? ::Audited.store[:current_controller]&.send(Audited.current_user_method).blank? : false
       end
     end # InstanceMethods
 

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -609,10 +609,14 @@ describe Audited::Auditor do
     before do
       Audited.only_authenticated_user = true
     end
-    
+
     it 'update company without audits' do
       company = Models::ActiveRecord::Company.create name: 'The auditors'
       expect { company.update_attributes name: 'New company name' }.to_not change( Audited.audit_class, :count )
+    end
+
+    after do
+      Audited.only_authenticated_user = false
     end
   end
 end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -604,4 +604,15 @@ describe Audited::Auditor do
       }.to_not change( Audited.audit_class, :count )
     end
   end
+
+  describe "Update only for authenticated user" do
+    before do
+      Audited.only_authenticated_user = true
+    end
+    
+    it 'update company without audits' do
+      company = Models::ActiveRecord::Company.create name: 'The auditors'
+      expect { company.update_attributes name: 'New company name' }.to_not change( Audited.audit_class, :count )
+    end
+  end
 end


### PR DESCRIPTION
Sometimes we have a lot of background tasks, which update models, and we have a lot of useless records into DB. 

This PR allow track only if user is authenticated.