### PR TITLE
Remove rails-observers dependency

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -16,7 +16,4 @@ end
 
 appraise 'rails50' do
   gem 'rails', '~> 5.0.0'
-
-  # The following needs to point to Github until the release of 0.1.3
-  gem 'rails-observers', github: 'rails/rails-observers', branch: 'master'
 end

--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ Add the gem to your Gemfile:
 gem "audited", "~> 4.3"
 ```
 
-If you are using rails 5.0, you would also need the following line in your Gemfile.
-```ruby
-gem "rails-observers", github: 'rails/rails-observers'
-```
-
 Then, from your Rails app directory, create the `audits` table:
 
 ```bash

--- a/audited.gemspec
+++ b/audited.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'activerecord', '>= 4.0', '< 5.1'
-  gem.add_dependency 'rails-observers', '~> 0.1.2'
 
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'rails', '>= 4.0', '< 5.1'

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
-gem "rails-observers", :github => "rails/rails-observers", :branch => "master"
 
 gemspec :name => "audited", :path => "../"

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -1,4 +1,3 @@
-require 'rails/observers/active_model/active_model'
 require 'active_record'
 
 module Audited

--- a/lib/audited/sweeper.rb
+++ b/lib/audited/sweeper.rb
@@ -1,60 +1,49 @@
-require "rails/observers/activerecord/active_record"
-require "rails/observers/action_controller/caching"
-
 module Audited
-  class Sweeper < ActionController::Caching::Sweeper
-    observe Audited::Audit
+  class Sweeper
+    STORED_DATA = {
+      current_remote_address: :remote_ip,
+      current_request_uuid: :request_uuid,
+      current_user: :current_user
+    }
+
+    delegate :store, to: ::Audited
 
     def around(controller)
       self.controller = controller
+      STORED_DATA.each { |k,m| store[k] = send(m) }
       yield
     ensure
       self.controller = nil
-    end
-
-    def before_create(audit)
-      audit.user ||= current_user
-      audit.remote_address = controller.try(:request).try(:remote_ip)
-      audit.request_uuid = request_uuid if request_uuid
+      STORED_DATA.keys.each { |k| store.delete(k) }
     end
 
     def current_user
       controller.send(Audited.current_user_method) if controller.respond_to?(Audited.current_user_method, true)
     end
 
+    def remote_ip
+      controller.try(:request).try(:remote_ip)
+    end
+
     def request_uuid
       controller.try(:request).try(:uuid)
     end
 
-    def add_observer!(klass)
-      super
-      define_callback(klass)
-    end
-
-    def define_callback(klass)
-      observer = self
-      callback_meth = :_notify_audited_sweeper
-      klass.send(:define_method, callback_meth) do
-        observer.update(:before_create, self)
-      end
-      klass.send(:before_create, callback_meth)
-    end
-
     def controller
-      ::Audited.store[:current_controller]
+      store[:current_controller]
     end
 
     def controller=(value)
-      ::Audited.store[:current_controller] = value
+      store[:current_controller] = value
     end
   end
 end
 
 ActiveSupport.on_load(:action_controller) do
   if defined?(ActionController::Base)
-    ActionController::Base.around_action Audited::Sweeper.instance
+    ActionController::Base.around_action Audited::Sweeper.new
   end
   if defined?(ActionController::API)
-    ActionController::API.around_action Audited::Sweeper.instance
+    ActionController::API.around_action Audited::Sweeper.new
   end
 end

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -191,7 +191,7 @@ describe Audited::Audit do
           raise StandardError.new('expected')
         end
       }.to raise_exception('expected')
-      expect(Thread.current[:audited_user]).to be_nil
+      expect(Audited.store[:audited_user]).to be_nil
     end
 
   end

--- a/spec/audited/sweeper_spec.rb
+++ b/spec/audited/sweeper_spec.rb
@@ -86,21 +86,23 @@ end
 describe Audited::Sweeper do
 
   it "should be thread-safe" do
+    instance = Audited::Sweeper.new
+
     t1 = Thread.new do
       sleep 0.5
-      Audited::Sweeper.instance.controller = 'thread1 controller instance'
-      expect(Audited::Sweeper.instance.controller).to eq('thread1 controller instance')
+      instance.controller = 'thread1 controller instance'
+      expect(instance.controller).to eq('thread1 controller instance')
     end
 
     t2 = Thread.new do
-      Audited::Sweeper.instance.controller = 'thread2 controller instance'
+      instance.controller = 'thread2 controller instance'
       sleep 1
-      expect(Audited::Sweeper.instance.controller).to eq('thread2 controller instance')
+      expect(instance.controller).to eq('thread2 controller instance')
     end
 
     t1.join; t2.join
 
-    expect(Audited::Sweeper.instance.controller).to be_nil
+    expect(instance.controller).to be_nil
   end
 
 end


### PR DESCRIPTION
The `Audited::Sweeper` class made limited use of the cache sweeping
functionality provided by rails-observer, mostly using it as a way to
implement `Audit#before_create` on the same class that was attached
around controller actions.

Since there is no released version of rails-observer that's compatible
with Rails 5.0 (and not in the foreseeable future without considerable
refactoring), the population of IPs, users and request UUIDs is replaced
by thread-local storage and the existing `Audit#before_create` methods.

This is a net code reduction and somewhat simplifies the "sweeper" by
removing the assumptions about how rails-observer works.