### PR TITLE
Add `update_with_only_comment` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ class User < ActiveRecord::Base
 end
 ```
 
+You can update an audit if only audit_comment is present. You can optionally add the `:update_with_comment_only` option set to `false` to your `audited` call to turn this behavior off for all audits.
+
+```ruby
+class User < ActiveRecord::Base
+  audited :update_with_comment_only => false
+end
+```
+
 ### Limiting stored audits
 
 You can limit the number of audits stored for your model. To configure limiting for all audited models, put the following in an initializer:

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -256,7 +256,7 @@ module Audited
       end
 
       def audit_update
-        unless (changes = audited_changes).empty? && audit_comment.blank?
+        unless (changes = audited_changes).empty? && (audit_comment.blank? || audited_options[:update_with_comment_only] == false)
           write_audit(action: 'update', audited_changes: changes,
                       comment: audit_comment)
         end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -889,6 +889,16 @@ describe Audited::Auditor do
 
   end
 
+  describe "no update with comment only" do
+    let( :user ) { Models::ActiveRecord::NoUpdateWithCommentOnlyUser.create }
+
+    it "does not create an audit when only an audit_comment is present" do
+      user.audit_comment = "Comment"
+      expect { user.save! }.to_not change( Audited::Audit, :count )
+    end
+
+  end
+
   describe "attr_protected and attr_accessible" do
 
     it "should not raise error when attr_accessible is set and protected is false" do

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -45,6 +45,11 @@ module Models
       audited comment_required: true, on: :destroy
     end
 
+    class NoUpdateWithCommentOnlyUser < ::ActiveRecord::Base
+      self.table_name = :users
+      audited update_with_comment_only: false
+    end
+
     class AccessibleAfterDeclarationUser < ::ActiveRecord::Base
       self.table_name = :users
       audited


### PR DESCRIPTION
Added on f2de4e606e97ec4c750dc9336d54cdffb88b7ab8
Currently there is a possibility to update an audit if only audit comment is present:

`assert_difference('post.audits.count', 1) { post.update_attributes(audit_comment: 'Only comment') }`

In my opinion, updating an audit with only comment given is purposeless, as in fact there are no changes at all

