### PR TITLE
Fix deprecated spec format

### DIFF
--- a/spec/audited/sweeper_spec.rb
+++ b/spec/audited/sweeper_spec.rb
@@ -76,7 +76,7 @@ describe AuditsController do
       controller.send(:current_user=, user)
 
       expect {
-        put :update, id: 123
+        put :update, params: { id: 123 }
       }.to_not change( Audited::Audit, :count )
     end
   end


### PR DESCRIPTION
DEPRECATION WARNING: Using positional arguments in functional tests has been deprecated,
in favor of keyword arguments