### PR TITLE
Fix AR/Rails gemspec dependencies to permit 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Fixed
 
 - None
 
+## 4.4.1 (2017-03-29)
+
+Fixed
+
+- Fix ActiveRecord gem dependency to permit 5.1
+  [#332](https://github.com/collectiveidea/audited/pull/332)
+
 ## 4.4.0 (2017-03-29)
 
 Breaking changes

--- a/audited.gemspec
+++ b/audited.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($\).reject{|f| f =~ /(\.gemspec)/ }
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'activerecord', '>= 4.0', '< 5.1'
+  gem.add_dependency 'activerecord', '>= 4.0', '< 5.2'
 
   gem.add_development_dependency 'appraisal'
-  gem.add_development_dependency 'rails', '>= 4.0', '< 5.1'
+  gem.add_development_dependency 'rails', '>= 4.0', '< 5.2'
   gem.add_development_dependency 'rspec-rails', '~> 3.5'
 
   # JRuby support for the test ENV

--- a/lib/audited/version.rb
+++ b/lib/audited/version.rb
@@ -1,3 +1,3 @@
 module Audited
-  VERSION = "4.4.0"
+  VERSION = "4.4.1"
 end


### PR DESCRIPTION
Sorry @danielmorrison, a daft error I only noticed when viewing the published gem at rubygems.org.