### PR TITLE
Support UUID primary keys for User

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ rails generate audited:install
 $ rake db:migrate
 ```
 
-If you're using PostgreSQL, then you can use `rails generate audited:install --audited-changes-column-type jsonb` (or `json`) to store audit changes natively with its JSON column types.
+If you're using PostgreSQL, then you can use `rails generate audited:install --audited-changes-column-type jsonb` (or `json`) to store audit changes natively with its JSON column types. If you're using something other than integer primary keys (e.g. UUID) for your User model, then you can use `rails generate audited:install --audited-user-id-column-type uuid` to customize the `audits` table `user_id` column type.
 
 #### Upgrading
 
@@ -169,6 +169,8 @@ Audited.audit_class.as_user(User.find(1)) do
 end
 post.audits.last.user # => #<User id: 1>
 ```
+
+The standard Audited install assumes your User model has an integer primary key type. If this isn't true (e.g. you're using UUID primary keys), you'll need to create a migration to update the `audits` table `user_id` column type. (See Installation above for generator flags if you'd like to regenerate the install migration.)
 
 #### Custom Auditor
 

--- a/lib/generators/audited/install_generator.rb
+++ b/lib/generators/audited/install_generator.rb
@@ -13,6 +13,7 @@ module Audited
       extend Audited::Generators::Migration
 
       class_option :audited_changes_column_type, type: :string, default: "text", required: false
+      class_option :audited_user_id_column_type, type: :string, default: "integer", required: false
 
       source_root File.expand_path("../templates", __FILE__)
 

--- a/lib/generators/audited/templates/install.rb
+++ b/lib/generators/audited/templates/install.rb
@@ -5,7 +5,7 @@ class <%= migration_class_name %> < <%= migration_parent %>
       t.column :auditable_type, :string
       t.column :associated_id, :integer
       t.column :associated_type, :string
-      t.column :user_id, :<%= options[:audited_changes_column_type] %>
+      t.column :user_id, :<%= options[:audited_user_id_column_type] %>
       t.column :user_type, :string
       t.column :username, :string
       t.column :action, :string

--- a/lib/generators/audited/templates/install.rb
+++ b/lib/generators/audited/templates/install.rb
@@ -5,7 +5,7 @@ class <%= migration_class_name %> < <%= migration_parent %>
       t.column :auditable_type, :string
       t.column :associated_id, :integer
       t.column :associated_type, :string
-      t.column :user_id, :integer
+      t.column :user_id, :<%= options[:audited_changes_column_type] %>
       t.column :user_type, :string
       t.column :username, :string
       t.column :action, :string

--- a/test/install_generator_test.rb
+++ b/test/install_generator_test.rb
@@ -34,6 +34,24 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "generate migration with 'string' type for user_id column" do
+    run_generator %w(--audited-user-id-column-type string)
+
+    assert_migration "db/migrate/install_audited.rb" do |content|
+      assert_includes(content, 'class InstallAudited')
+      assert_includes(content, 't.column :user_id, :string')
+    end
+  end
+
+  test "generate migration with 'uuid' type for user_id column" do
+    run_generator %w(--audited-user-id-column-type uuid)
+
+    assert_migration "db/migrate/install_audited.rb" do |content|
+      assert_includes(content, 'class InstallAudited')
+      assert_includes(content, 't.column :user_id, :uuid')
+    end
+  end
+
   test "generate migration with correct AR migration parent" do
     run_generator
 


### PR DESCRIPTION
We use `uuid` as our primary key type on `users`, so we needed to tweak the install migration and are submitting back a generator option here.

If this is acceptable, I'm happy to add usage instructions to README.