### PR TITLE
Allow redacting specific attributes from audits

### DIFF
--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -58,6 +58,16 @@ describe Audited::Auditor do
       expect(user.audits.last.audited_changes.keys).to eq(%w{password})
     end
 
+    it "should redact columns specified in 'redacted' option" do
+      redacted = Audited::Auditor::AuditedInstanceMethods::REDACTED
+      user = Models::ActiveRecord::UserRedactedPassword.create(password: "password")
+      user.save!
+      expect(user.audits.last.audited_changes['password']).to eq(redacted)
+      user.password = "new_password"
+      user.save!
+      expect(user.audits.last.audited_changes['password']).to eq([redacted, redacted])
+    end
+
     if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL' && Rails.version >= "4.2.0.0" # Postgres json and jsonb support was added in Rails 4.2
       describe "'json' and 'jsonb' audited_changes column type" do
         let(:migrations_path) { SPEC_ROOT.join("support/active_record/postgres") }

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -24,6 +24,11 @@ module Models
       audited comment_required: true
     end
 
+    class UserRedactedPassword < ::ActiveRecord::Base
+      self.table_name = :users
+      audited redacted: :password
+    end
+
     class AccessibleAfterDeclarationUser < ::ActiveRecord::Base
       self.table_name = :users
       audited


### PR DESCRIPTION
This allows users to define attributed which should be audited when
changed without saving the actual change in the audit log - for example
for passwords or secret keys.