### PR TITLE
Call controller's current_user method during audited model creation

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -158,7 +158,7 @@ module Audited
 
     def set_audit_user
       self.user ||= ::Audited.store[:audited_user] # from .as_user
-      self.user ||= ::Audited.store[:current_user] # from Sweeper
+      self.user ||= ::Audited.store[:current_user].try!(:call) # from Sweeper
       nil # prevent stopping callback chains
     end
 

--- a/lib/audited/sweeper.rb
+++ b/lib/audited/sweeper.rb
@@ -18,7 +18,7 @@ module Audited
     end
 
     def current_user
-      controller.send(Audited.current_user_method) if controller.respond_to?(Audited.current_user_method, true)
+      lambda { controller.send(Audited.current_user_method) if controller.respond_to?(Audited.current_user_method, true) }
     end
 
     def remote_ip

--- a/spec/audited/sweeper_spec.rb
+++ b/spec/audited/sweeper_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 class AuditsController < ActionController::Base
+  before_action :populate_user
+
   attr_reader :company
 
   def create
@@ -17,6 +19,8 @@ class AuditsController < ActionController::Base
 
   attr_accessor :current_user
   attr_accessor :custom_user
+
+  def populate_user; end
 end
 
 describe AuditsController do
@@ -67,6 +71,18 @@ describe AuditsController do
       post :create
 
       expect(controller.company.audits.last.request_uuid).to eq("abc123")
+    end
+
+    it "should call current_user after controller callbacks" do
+      expect(controller).to receive(:populate_user) do
+        controller.send(:current_user=, user)
+      end
+
+      expect {
+        post :create
+      }.to change( Audited::Audit, :count )
+
+      expect(controller.company.audits.last.user).to eq(user)
     end
 
   end


### PR DESCRIPTION
Restores behaviour prior to 87d402a where the sweeper would call the
controller's current_user method from the audited model callback.

Since 87d402a, the current_user method was called from an around action
callback registered on the base controller which was being called prior
to other callbacks that were authenticating the user. This caused
problems in apps where the user hadn't yet been set (so audit users were
nil), or CSRF issues because current_user was called prior to session
changes.

Fixes #336