### PR TITLE
Allowing using symbol keys in `non_audited_columns`

### DIFF
--- a/audited.gemspec
+++ b/audited.gemspec
@@ -34,4 +34,3 @@ Gem::Specification.new do |gem|
     gem.add_development_dependency 'pg', '~> 0.18'
   end
 end
-

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -129,7 +129,7 @@ module Audited
 
       # List of attributes that are audited.
       def audited_attributes
-        attributes.except(*non_audited_columns)
+        attributes.except(*non_audited_columns.map(&:to_s))
       end
 
       def non_audited_columns
@@ -251,7 +251,7 @@ module Audited
     module AuditedClassMethods
       # Returns an array of columns that are audited. See non_audited_columns
       def audited_columns
-        columns.select {|c| !non_audited_columns.include?(c.name) }
+        columns.reject { |c| non_audited_columns.map(&:to_s).include?(c.name) }
       end
 
       def non_audited_columns

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -36,7 +36,9 @@ describe Audited::Auditor do
     end
 
     it "should not save non-audited columns" do
-      expect(create_user.audits.first.audited_changes.keys.any? { |col| ['created_at', 'updated_at', 'password'].include?( col ) }).to eq(false)
+      Models::ActiveRecord::User.non_audited_columns = (Models::ActiveRecord::User.non_audited_columns << :favourite_device)
+
+      expect(create_user.audits.first.audited_changes.keys.any? { |col| ['favourite_device', 'created_at', 'updated_at', 'password'].include?( col ) }).to eq(false)
     end
 
     it "should not save other columns than specified in 'only' option" do

--- a/spec/audited_spec_helpers.rb
+++ b/spec/audited_spec_helpers.rb
@@ -1,7 +1,7 @@
 module AuditedSpecHelpers
 
   def create_user(attrs = {})
-    Models::ActiveRecord::User.create({name: 'Brandon', username: 'brandon', password: 'password'}.merge(attrs))
+    Models::ActiveRecord::User.create({name: 'Brandon', username: 'brandon', password: 'password', favourite_device: 'Android Phone'}.merge(attrs))
   end
 
   def build_user(attrs = {})

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define do
     t.column :logins, :integer, default: 0
     t.column :created_at, :datetime
     t.column :updated_at, :datetime
+    t.column :favourite_device, :string
   end
 
   create_table :companies do |t|


### PR DESCRIPTION
Right now, even though the README file mentions symbol keys in `non_audited_columns`, they don't get filtered out as expected. To get `non_audited_columns` working as expected you have to pass the attribute names as strings.

This PR allows passing symbol keys.
