### PR TITLE
Fix change of  vritual attribute can not be tracked.

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -184,7 +184,7 @@ module Audited
           end
 
         collection.inject({}) do |changes, (attr, old_value)|
-          changes[attr] = [old_value, self[attr]]
+          changes[attr] = [old_value, self.public_send(attr)]
           changes
         end
       end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -180,6 +180,12 @@ describe Audited::Auditor do
       expect(@user.audits.last.audited_changes).to eq({ 'name' => ['Brandon', 'Changed'] })
     end
 
+    it "should store the change of the custom attribute which extended dirty feature" do
+			@user = Models::ActiveRecord::UserDelegateCompany.create(name: 'Brandon', username: 'brandon', password: 'password')
+      @user.update_attributes company_list: 'apple,google'
+      expect(@user.audits.last.audited_changes).to eq({ 'company_list' => ['', 'apple,google'] })
+    end
+
     it "should store audit comment" do
       expect(@user.audits.last.comment).to eq('Update')
     end


### PR DESCRIPTION
Some gems like "acts-as-taggable-on" may add some vritual attribute/method that inherits activerecord dirty feature. Please see the follow links:

[https://github.com/mbleigh/acts-as-taggable-on/blob/64ed839a8a6021c719fbff9c6bdf74a4fcd65f18/lib/acts_as_taggable_on/taggable/core.rb#L193](https://github.com/mbleigh/acts-as-taggable-on/blob/64ed839a8a6021c719fbff9c6bdf74a4fcd65f18/lib/acts_as_taggable_on/taggable/core.rb#L193)
[https://github.com/mbleigh/acts-as-taggable-on/blob/8e64c3d4a81cfbb8af621228eae36a65c1f94501/lib/acts_as_taggable_on/taggable/dirty.rb#L14](https://github.com/mbleigh/acts-as-taggable-on/blob/8e64c3d4a81cfbb8af621228eae36a65c1f94501/lib/acts_as_taggable_on/taggable/dirty.rb#L14)

[https://github.com/collectiveidea/audited/blob/master/lib/audited/auditor.rb#L187](Audited::Auditor#audited_changes) uses rails "[](attr_name)" method to fetch the new value of changed attribute which leads those gems that didn't extend this method to return nil (please see the test example added).

so I change the method to public_send to solve this problem.
