### PR TITLE
display class and id for deleted users

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -117,7 +117,7 @@ module Audited
 
     # @private
     def user_as_string
-      user_as_model || username
+      user_as_model || username || ("#{user_type}##{user_id}" if user_type && user_id)
     end
     alias_method :user_as_model, :user
     alias_method :user, :user_as_string

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -133,6 +133,12 @@ describe Audited::Audit do
       subject.user = user
       expect(subject.username).to be_nil
     end
+
+    it "should find deleted user" do
+      subject.user_type = user.class.name
+      subject.user_id = 123
+      expect(subject.user).to be_nil
+    end
   end
 
   describe "revision" do


### PR DESCRIPTION
was about to make a PR when I realized it's not that easy ... since user should behave like a AR and most likely not return a weird string ... maybe user_as_string should do that instead and user should be aliased to something else ... idk ... 
/fyi @danielmorrison 