### PR TITLE
Fix typo in Audited RSpec Matchers

### DIFF
--- a/lib/audited/rspec_matchers.rb
+++ b/lib/audited/rspec_matchers.rb
@@ -117,7 +117,7 @@ module Audited
             except |= @options[:except].collect(&:to_s) if @options[:except]
           end
 
-          expects "non audited columns (#{model_class.non_audited_columns.inspect}) to match (#{expect})"
+          expects "non audited columns (#{model_class.non_audited_columns.inspect}) to match (#{except})"
           model_class.non_audited_columns =~ except
         else
           true


### PR DESCRIPTION
Currently, the audited RSpec matchers throw an error:
`undefined local variable or method 'expect' for <Audited::RspecMatchers::AuditMatcher:0x007f8627d6ae48>`
when you use `.only` or `.except`.

The issue was a typo where it was referring to a non-existent variable `expect` instead of `except`.

Response to: https://github.com/collectiveidea/audited/issues/359