### PR TITLE
Test Ruby 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache: bundler
 rvm:
   - 2.1
+  - 2.2.2
   - 2.2.4
   - 2.3.1
   - 2.4.1

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For Rails 3, use gem version 3.0 or see the [3.0-stable branch](https://github.c
 Audited supports and is [tested against](http://travis-ci.org/collectiveidea/audited) the following Ruby versions:
 
 * 2.1.5
+* 2.2.2
 * 2.2.4
 * 2.3.1
 * 2.4.1


### PR DESCRIPTION
I'm hoping that this is enough to run Travis against Ruby 2.2.2.  

Rspec tests pass locally on 2.2.2.

Please advise if more is required.