### PR TITLE
Remove automatic Sweeper install

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,15 +143,23 @@ end
 
 ### Current User Tracking
 
-If you're using Audited in a Rails application, all audited changes made within a request will automatically be attributed to the current user. By default, Audited uses the `current_user` method in your controller.
+If you're using Audited in a Rails application, add around callback for actions you want to track changes in.
+All audited changes made within a request will automatically be attributed to the current user. By default, Audited uses the `current_user` method in your controller.
 
 ```ruby
 class PostsController < ApplicationController
+  around_action Audited::Sweeper.new
+
   def create
     current_user # => #<User name: "Steve">
     @post = Post.create(params[:post])
     @post.audits.last.user # => #<User name: "Steve">
   end
+end
+
+# or enable this callback for all controllers:
+class ApplicationController < ActionController::Base
+  around_action Audited::Sweeper.new
 end
 ```
 

--- a/lib/audited/sweeper.rb
+++ b/lib/audited/sweeper.rb
@@ -38,12 +38,3 @@ module Audited
     end
   end
 end
-
-ActiveSupport.on_load(:action_controller) do
-  if defined?(ActionController::Base)
-    ActionController::Base.around_action Audited::Sweeper.new
-  end
-  if defined?(ActionController::API)
-    ActionController::API.around_action Audited::Sweeper.new
-  end
-end

--- a/spec/audited/sweeper_spec.rb
+++ b/spec/audited/sweeper_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 class AuditsController < ActionController::Base
+  around_action Audited::Sweeper.new
   before_action :populate_user
 
   attr_reader :company

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@ require 'rspec/rails'
 require 'audited'
 require 'audited_spec_helpers'
 require 'support/active_record/models'
-load "audited/sweeper.rb" # force to reload sweeper
 
 SPEC_ROOT = Pathname.new(File.expand_path('../', __FILE__))
 


### PR DESCRIPTION
Load hook runs twice in rails 5, so callbacks will also run twice.
And there was no way to disable sweeper for particular controllers.