### PR TITLE
Fix deprecation warnings caused by using changed_attributes

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -178,9 +178,9 @@ module Audited
         collection =
           if audited_options[:only]
             audited_columns = self.class.audited_columns.map(&:name)
-            changed_attributes.slice(*audited_columns)
+            attributes_in_database.slice(*audited_columns)
           else
-            changed_attributes.except(*non_audited_columns)
+            attributes_in_database.except(*non_audited_columns)
           end
 
         collection.inject({}) do |changes, (attr, old_value)|


### PR DESCRIPTION
This fixes #371 

I've been running this locally on my own installation and everything seems to be working fine. The new `attributes_in_database` method is meant to be a drop in replacement for `changed_attributes` so there shouldn't be any problems with it.