### PR TITLE
Return nil on invalid revision number

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -119,7 +119,7 @@ module Audited
       # Get a specific revision specified by the version number, or +:previous+
       # Returns nil for versions greater than revisions count
       def revision(version)
-        if version == :previous || revisions.count >= version
+        if version == :previous || self.audits.last.version >= version
           revision_with Audited.audit_class.reconstruct_attributes(audits_to(version))
         end
       end

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -117,8 +117,11 @@ module Audited
       end
 
       # Get a specific revision specified by the version number, or +:previous+
+      # Returns nil for versions greater than revisions count
       def revision(version)
-        revision_with Audited.audit_class.reconstruct_attributes(audits_to(version))
+        if version == :previous || revisions.count >= version
+          revision_with Audited.audit_class.reconstruct_attributes(audits_to(version))
+        end
       end
 
       # Find the oldest revision recorded prior to the date/time provided.

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -452,6 +452,10 @@ describe Audited::Auditor do
         user.revision(1).save!
       }.to change( Models::ActiveRecord::User, :count ).by(1)
     end
+
+    it "should return nil for values greater than the number of revisions" do
+      expect(user.revision(user.revisions.count + 1)).to be_nil
+    end
   end
 
   describe "revision_at" do


### PR DESCRIPTION
* Previously, when a `record.revision(version)` was called
  with a version number that was greater than the total
  number of revisions, it would return the last revision
  in the list. This changes it to return nil.

This addresses this issue raised here > https://github.com/collectiveidea/audited/issues/321.