### PR TITLE
Columns order adjustment for polymorphic indexes

### DIFF
--- a/lib/generators/audited/templates/install.rb
+++ b/lib/generators/audited/templates/install.rb
@@ -17,8 +17,8 @@ class <%= migration_class_name %> < <%= migration_parent %>
       t.column :created_at, :datetime
     end
 
-    add_index :audits, [:auditable_id, :auditable_type], :name => 'auditable_index'
-    add_index :audits, [:associated_id, :associated_type], :name => 'associated_index'
+    add_index :audits, [:auditable_type, :auditable_id], :name => 'auditable_index'
+    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index'
     add_index :audits, [:user_id, :user_type], :name => 'user_index'
     add_index :audits, :request_uuid
     add_index :audits, :created_at

--- a/lib/generators/audited/templates/revert_polymorphic_indexes_order.rb
+++ b/lib/generators/audited/templates/revert_polymorphic_indexes_order.rb
@@ -1,0 +1,20 @@
+class <%= migration_class_name %> < <%= migration_parent %>
+  def self.up
+    fix_index_order_for [:associated_id, :associated_type], 'associated_index'
+    fix_index_order_for [:auditable_id, :auditable_type], 'auditable_index'
+  end
+
+  def self.down
+    fix_index_order_for [:associated_type, :associated_id], 'associated_index'
+    fix_index_order_for [:auditable_type, :auditable_id], 'auditable_index'
+  end
+
+  private
+
+  def fix_index_order_for(columns, index_name)
+    if index_exists? :audits, columns, name: index_name
+      remove_index :audits, name: index_name
+      add_index :audits, columns.reverse, name: index_name
+    end
+  end
+end

--- a/lib/generators/audited/upgrade_generator.rb
+++ b/lib/generators/audited/upgrade_generator.rb
@@ -25,6 +25,7 @@ module Audited
       def migrations_to_be_applied
         Audited::Audit.reset_column_information
         columns = Audited::Audit.columns.map(&:name)
+        indexes = Audited::Audit.connection.indexes(Audited::Audit.table_name)
 
         yield :add_comment_to_audits unless columns.include?('comment')
 
@@ -52,6 +53,10 @@ module Audited
 
         if columns.include?('association_id')
           yield :rename_association_to_associated
+        end
+
+        if indexes.any? { |i| i.columns == %w[associated_id associated_type] }
+          yield :revert_polymorphic_indexes_order
         end
       end
     end


### PR DESCRIPTION
Current auditable & associated polymorphic indexes are using suboptimal columns order. PR for fixing order according to current Rails behavior in context of index structure for polymorphic association (https://github.com/rails/rails/commit/9cdd0a1fdf8308985231242d378e3a1c29c4ab00)