### PR TITLE
Simplify audited_changes

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -179,17 +179,11 @@ module Audited
       private
 
       def audited_changes
-        all_changes = respond_to?(:attributes_in_database) ? attributes_in_database : changed_attributes
-        collection =
-          if audited_options[:only]
-            all_changes.slice(*audited_columns)
-          else
-            all_changes.except(*non_audited_columns)
-          end
-
-        collection.inject({}) do |changes, (attr, old_value)|
-          changes[attr] = [old_value, self[attr]]
-          changes
+        all_changes = respond_to?(:changes_to_save) ? changes_to_save : changes
+        if audited_options[:only]
+          all_changes.slice(*audited_columns)
+        else
+          all_changes.except(*non_audited_columns)
         end
       end
 


### PR DESCRIPTION
`changes` (or `changes_to_save` in Rails>5.1) already gives us all the
changes in the format we need for saving the audit, no need to build
the hash again by ourselves.