### PR TITLE
Normalize options on initialization and minor cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Changed
   [#391](https://github.com/collectiveidea/audited/pull/391)
 - Simplify `audited_changes` calculation
   [#389](https://github.com/collectiveidea/audited/pull/389)
+- Normalize options passed to `audited` method
+  [#397](https://github.com/collectiveidea/audited/pull/397)
 
 Fixed
 

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -60,6 +60,25 @@ describe Audited::Auditor do
       expect(user.audits.last.audited_changes.keys).to eq(%w{password})
     end
 
+    it "should save attributes not specified in 'except' option" do
+      user = Models::ActiveRecord::User.create
+      user.instance_eval do
+        def non_column_attr
+          @non_column_attr
+        end
+
+        def non_column_attr=(val)
+          attribute_will_change!("non_column_attr")
+          @non_column_attr = val
+        end
+      end
+
+      user.password = "password"
+      user.non_column_attr = "some value"
+      user.save!
+      expect(user.audits.last.audited_changes.keys).to eq(%w{non_column_attr})
+    end
+
     if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL' && Rails.version >= "4.2.0.0" # Postgres json and jsonb support was added in Rails 4.2
       describe "'json' and 'jsonb' audited_changes column type" do
         let(:migrations_path) { SPEC_ROOT.join("support/active_record/postgres") }

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -5,7 +5,7 @@ module Models
   module ActiveRecord
     class User < ::ActiveRecord::Base
       audited allow_mass_assignment: true, except: :password
-
+      attribute :non_column_attr if Rails.version >= '5.1'
       attr_protected :logins if respond_to?(:attr_protected)
 
       def name=(val)


### PR DESCRIPTION
Normalizing options passed on audited initialization simplifies code in
further steps. Also cleaned up the code a bit.