### PR TITLE
Optimize reconstructing attributes in #revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Added
 
 Changed
 
-- None
+- Reduced db calls in #revisions method
+  [#402](https://github.com/collectiveidea/audited/pull/402)
+  [#403](https://github.com/collectiveidea/audited/pull/403)
 
 Fixed
 


### PR DESCRIPTION
Follow up of https://github.com/collectiveidea/audited/pull/402.

Also replaced `.empty?` with `.exists?`, because for older rails'es (at least for 4.0.0) `.empty?` is implemented through `COUNT`, instead of through `SELECT 1` like in new versions.