### PR TITLE
Remove references to no-longer-supported allow_mass_assigment

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,30 +278,6 @@ Audited.config do |config|
 end
 ```
 
-## Gotchas
-
-### Using attr_protected with Rails 4.x
-
-If you're using the `protected_attributes` gem with Rails 4.0, 4.1 or 4.2 (the gem isn't supported in Rails 5.0 or higher), you'll have to take an extra couple of steps to get `audited` working.
-
-First be sure to add `allow_mass_assignment: true` to your `audited` call; otherwise Audited will
-interfere with `protected_attributes` and none of your `save` calls will work.
-
-```ruby
-class User < ActiveRecord::Base
-  audited allow_mass_assignment: true
-end
-```
-
-Second, be sure to add `audit_ids` to the list of protected attributes to prevent data loss.
-
-```ruby
-class User < ActiveRecord::Base
-  audited allow_mass_assignment: true
-  attr_protected :logins, :audit_ids
-end
-```
-
 ## Support
 
 You can find documentation at: http://rdoc.info/github/collectiveidea/audited

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -4,7 +4,7 @@ require File.expand_path('../schema', __FILE__)
 module Models
   module ActiveRecord
     class User < ::ActiveRecord::Base
-      audited allow_mass_assignment: true, except: :password
+      audited except: :password
       attribute :non_column_attr if Rails.version >= '5.1'
       attr_protected :logins if respond_to?(:attr_protected)
 
@@ -16,7 +16,7 @@ module Models
     class UserOnlyPassword < ::ActiveRecord::Base
       self.table_name = :users
       attribute :non_column_attr if Rails.version >= '5.1'
-      audited allow_mass_assignment: true, only: :password
+      audited only: :password
     end
 
     class CommentRequiredUser < ::ActiveRecord::Base
@@ -38,7 +38,7 @@ module Models
 
     class NoAttributeProtectionUser < ::ActiveRecord::Base
       self.table_name = :users
-      audited allow_mass_assignment: true
+      audited
     end
 
     class UserWithAfterAudit < ::ActiveRecord::Base


### PR DESCRIPTION
As pointed out in issue #223, `allow_mass_assigment` has been removed and no longer has any effect. This updates the docs to no longer talk about it as it causes confusion to users of the gem.