### PR TITLE
Fix migrations in tests for rails 5.2

### DIFF
--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", ">= 5.2.0.beta2", "< 5.3"
+gem "rails", ">= 5.2.0.rc1", "< 5.3"
 gem "mysql2", "~> 0.4.4"
 
 gemspec name: "audited", path: "../"

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -84,11 +84,11 @@ describe Audited::Auditor do
         let(:migrations_path) { SPEC_ROOT.join("support/active_record/postgres") }
 
         after do
-          ActiveRecord::Migrator.rollback([migrations_path])
+          run_migrations(:down, migrations_path)
         end
 
         it "should work if column type is 'json'" do
-          ActiveRecord::Migrator.up([migrations_path], 1)
+          run_migrations(:up, migrations_path, 1)
           Audited::Audit.reset_column_information
           expect(Audited::Audit.columns_hash["audited_changes"].sql_type).to eq("json")
 
@@ -99,7 +99,7 @@ describe Audited::Auditor do
         end
 
         it "should work if column type is 'jsonb'" do
-          ActiveRecord::Migrator.up([migrations_path], 2)
+          run_migrations(:up, migrations_path, 2)
           Audited::Audit.reset_column_information
           expect(Audited::Audit.columns_hash["audited_changes"].sql_type).to eq("jsonb")
 

--- a/spec/audited_spec_helpers.rb
+++ b/spec/audited_spec_helpers.rb
@@ -17,4 +17,16 @@ module AuditedSpecHelpers
     end
   end
 
+  def run_migrations(direction, migrations_paths, target_version = nil)
+    if rails_below?('5.2.0.rc1')
+      ActiveRecord::Migrator.send(direction, migrations_paths, target_version)
+    else
+      ActiveRecord::MigrationContext.new(migrations_paths).send(direction, target_version)
+    end
+  end
+
+  def rails_below?(rails_version)
+    Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new(rails_version)
+  end
+
 end


### PR DESCRIPTION
Rails 5.2.rc1 [introduced](https://github.com/rails/rails/pull/31727) some breaking changes for `ActiveRecord::Migrator`, so this PR fixes tests according to new changes.