### PR TITLE
Add inverse_of to audit relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Breaking changes
 
 Added
 
-- None
+- Add `inverse_of: auditable` definition to audit relation
+  [#413](https://github.com/collectiveidea/audited/pull/413)
 
 Changed
 

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -55,7 +55,7 @@ module Audited
           before_destroy :require_comment
         end
 
-        has_many :audits, -> { order(version: :asc) }, as: :auditable, class_name: Audited.audit_class.name
+        has_many :audits, -> { order(version: :asc) }, as: :auditable, class_name: Audited.audit_class.name, inverse_of: :auditable
         Audited.audit_class.audited_class_names << to_s
 
         after_create :audit_create    if audited_options[:on].include?(:create)


### PR DESCRIPTION
This allows access to the audited object's relations from inside audits
without reloading it from the database. This is useful, for example, if
you want to check has_many relations which are deleted from the database
before the audit callback is executed.