### PR TITLE
Re-fix honoring of 'except' when used with 'comment_required'

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -63,7 +63,7 @@ module Audited
         self.audit_associated_with = audited_options[:associated_with]
 
         if audited_options[:comment_required]
-          validate :presence_of_audit_comment
+          validates_presence_of :audit_comment, if: :eligible_for_comment_validation?
           before_destroy :require_comment if audited_options[:on].include?(:destroy)
         end
 
@@ -250,16 +250,16 @@ module Audited
         end
       end
 
-      def presence_of_audit_comment
-        if comment_required_state?
-          errors.add(:audit_comment, "Comment can't be blank!") unless audit_comment.present?
+      def eligible_for_comment_validation?
+        if !auditing_enabled ||
+          (audited_options[:on].exclude?(:create) && self.new_record?) ||
+          (audited_options[:on].exclude?(:update) && self.persisted?) ||
+          (audited_changes.empty? && self.persisted?)
+        then
+          false
+        else
+          true
         end
-      end
-
-      def comment_required_state?
-        auditing_enabled &&
-          ((audited_options[:on].include?(:create) && self.new_record?) ||
-          (audited_options[:on].include?(:update) && self.persisted? && self.changed?))
       end
 
       def combine_audits_if_needed

--- a/lib/audited/rspec_matchers.rb
+++ b/lib/audited/rspec_matchers.rb
@@ -114,7 +114,7 @@ module Audited
 
       def comment_required_valid?
         expects "to require audit_comment before #{model_class.audited_options[:on]} when comment required"
-        validate_callbacks_include_presence_of_comment? && destroy_callbacks_include_comment_required?
+        validations_include_presence_of_comment? && destroy_callbacks_include_comment_required?
       end
 
       def only_audit_on_designated_callbacks?
@@ -128,9 +128,9 @@ module Audited
         end.compact.all?
       end
 
-      def validate_callbacks_include_presence_of_comment?
+      def validations_include_presence_of_comment?
         if @options[:comment_required] && audited_on_create_or_update?
-          callbacks_for(:validate).include?(:presence_of_audit_comment)
+          model_class.validators_on(:audit_comment).present?
         else
           true
         end


### PR DESCRIPTION
This was originally fixed here: https://github.com/collectiveidea/audited/pull/419

But it was inadvertently broken when this was merged in: https://github.com/collectiveidea/audited/pull/420