### PR TITLE
Add ability to globally disable auditing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Breaking changes
 
 Added
 
-- None
+- Add ability to globally disable auditing
+  [#426](https://github.com/collectiveidea/audited/pull/426)
 
 Changed
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ User.auditing_enabled = false
 To disable auditing on all models:
 
 ```ruby
-Audited.disable_auditing
+Audited.auditing_enabled = false
 ```
 
 ### Custom `Audit` model

--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ To disable auditing on an entire model:
 User.auditing_enabled = false
 ```
 
+To disable auditing on all models:
+
+```ruby
+Audited.disable_auditing
+```
+
 ### Custom `Audit` model
 
 If you want to extend or modify the audit model, create a new class that

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -9,6 +9,18 @@ module Audited
       @audit_class ||= Audit
     end
 
+    def enable_auditing
+      store[:auditing_enabled] = nil
+    end
+
+    def disable_auditing
+      store[:auditing_enabled] = false
+    end
+
+    def auditing_enabled?
+      store[:auditing_enabled].nil? || store[:auditing_enabled]
+    end
+
     def store
       Thread.current[:audited_store] ||= {}
     end

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -2,23 +2,11 @@ require 'active_record'
 
 module Audited
   class << self
-    attr_accessor :ignored_attributes, :current_user_method, :max_audits
+    attr_accessor :ignored_attributes, :current_user_method, :max_audits, :auditing_enabled
     attr_writer :audit_class
 
     def audit_class
       @audit_class ||= Audit
-    end
-
-    def enable_auditing
-      store[:auditing_enabled] = nil
-    end
-
-    def disable_auditing
-      store[:auditing_enabled] = false
-    end
-
-    def auditing_enabled?
-      store[:auditing_enabled].nil? || store[:auditing_enabled]
     end
 
     def store
@@ -33,6 +21,7 @@ module Audited
   @ignored_attributes = %w(lock_version created_at updated_at created_on updated_on)
 
   @current_user_method = :current_user
+  @auditing_enabled = true
 end
 
 require 'audited/auditor'

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -285,7 +285,8 @@ module Audited
       def auditing_enabled
         return run_conditional_check(audited_options[:if]) &&
           run_conditional_check(audited_options[:unless], matching: false) &&
-          self.class.auditing_enabled
+          self.class.auditing_enabled &&
+          Audited.auditing_enabled?
       end
 
       def run_conditional_check(condition, matching: true)
@@ -355,7 +356,7 @@ module Audited
       end
 
       def auditing_enabled
-        Audited.store.fetch("#{table_name}_auditing_enabled", true)
+        Audited.store.fetch("#{table_name}_auditing_enabled", true) && Audited.auditing_enabled?
       end
 
       def auditing_enabled=(val)

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -285,8 +285,7 @@ module Audited
       def auditing_enabled
         return run_conditional_check(audited_options[:if]) &&
           run_conditional_check(audited_options[:unless], matching: false) &&
-          self.class.auditing_enabled &&
-          Audited.auditing_enabled?
+          self.class.auditing_enabled
       end
 
       def run_conditional_check(condition, matching: true)
@@ -356,7 +355,7 @@ module Audited
       end
 
       def auditing_enabled
-        Audited.store.fetch("#{table_name}_auditing_enabled", true) && Audited.auditing_enabled?
+        Audited.store.fetch("#{table_name}_auditing_enabled", true) && Audited.auditing_enabled
       end
 
       def auditing_enabled=(val)

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -725,16 +725,14 @@ describe Audited::Auditor do
     end
 
     it "should not save an audit when auditing is globally disabled" do
-      expect(Audited.auditing_enabled?).to eq(true)
-      Audited.disable_auditing
-      expect(Audited.auditing_enabled?).to eq(false)
+      expect(Audited.auditing_enabled).to eq(true)
+      Audited.auditing_enabled = false
       expect(Models::ActiveRecord::User.auditing_enabled).to eq(false)
 
       user = create_user
       expect(user.audits.count).to eq(0)
 
-      Audited.enable_auditing
-      expect(Audited.auditing_enabled?).to eq(true)
+      Audited.auditing_enabled = true
       expect(Models::ActiveRecord::User.auditing_enabled).to eq(true)
 
       user.update_attributes(name: 'Test')

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -723,6 +723,23 @@ describe Audited::Auditor do
         STDERR.puts "Thread safety tests cannot be run with SQLite"
       end
     end
+
+    it "should not save an audit when auditing is globally disabled" do
+      expect(Audited.auditing_enabled?).to eq(true)
+      Audited.disable_auditing
+      expect(Audited.auditing_enabled?).to eq(false)
+      expect(Models::ActiveRecord::User.auditing_enabled).to eq(false)
+
+      user = create_user
+      expect(user.audits.count).to eq(0)
+
+      Audited.enable_auditing
+      expect(Audited.auditing_enabled?).to eq(true)
+      expect(Models::ActiveRecord::User.auditing_enabled).to eq(true)
+
+      user.update_attributes(name: 'Test')
+      expect(user.audits.count).to eq(1)
+    end
   end
 
   describe "comment required" do


### PR DESCRIPTION
For minitest, for example:
Add to `test/test_helper.rb`:
```ruby
Audited.disable_auditing
```
And use:
```ruby
class UserTest < Minitest::Test
  def setup
    Audited.enable_auditing
  end

  def teardown
    Audited.disable_auditing
  end

  def test_auditing
    user = User.create!(name: "Dima", username: "dima")
    assert_equal 0, user.audits.count 
  end
end
```

Fixes #410