### PR TITLE
Add version to auditable_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Added
 
 Changed
 
-- None
+- Add version to auditable_index
+  [#427](https://github.com/collectiveidea/audited/pull/427)
 
 Fixed
 

--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -171,7 +171,7 @@ module Audited
     private
 
     def set_version_number
-      max = self.class.auditable_finder(auditable_id, auditable_type).descending.first.try(:version) || 0
+      max = self.class.auditable_finder(auditable_id, auditable_type).maximum(:version) || 0
       self.version = max + 1
     end
 

--- a/lib/generators/audited/templates/add_version_to_auditable_index.rb
+++ b/lib/generators/audited/templates/add_version_to_auditable_index.rb
@@ -1,0 +1,21 @@
+class <%= migration_class_name %> < <%= migration_parent %>
+  def self.up
+    if index_exists?(:audits, [:auditable_type, :auditable_id], name: index_name)
+      remove_index :audits, name: index_name
+      add_index :audits, [:auditable_type, :auditable_id, :version], name: index_name
+    end
+  end
+
+  def self.down
+    if index_exists?(:audits, [:auditable_type, :auditable_id, :version], name: index_name)
+      remove_index :audits, name: index_name
+      add_index :audits, [:auditable_type, :auditable_id], name: index_name
+    end
+  end
+
+  private
+
+  def index_name
+    'auditable_index'
+  end
+end

--- a/lib/generators/audited/templates/install.rb
+++ b/lib/generators/audited/templates/install.rb
@@ -17,7 +17,7 @@ class <%= migration_class_name %> < <%= migration_parent %>
       t.column :created_at, :datetime
     end
 
-    add_index :audits, [:auditable_type, :auditable_id], :name => 'auditable_index'
+    add_index :audits, [:auditable_type, :auditable_id, :version], :name => 'auditable_index'
     add_index :audits, [:associated_type, :associated_id], :name => 'associated_index'
     add_index :audits, [:user_id, :user_type], :name => 'user_index'
     add_index :audits, :request_uuid

--- a/lib/generators/audited/upgrade_generator.rb
+++ b/lib/generators/audited/upgrade_generator.rb
@@ -58,6 +58,10 @@ module Audited
         if indexes.any? { |i| i.columns == %w[associated_id associated_type] }
           yield :revert_polymorphic_indexes_order
         end
+
+        if indexes.any? { |i| i.columns == %w[auditable_type auditable_id] }
+          yield :add_version_to_auditable_index
+        end
       end
     end
   end

--- a/test/db/version_6.rb
+++ b/test/db/version_6.rb
@@ -14,4 +14,6 @@ ActiveRecord::Schema.define do
     t.column :associated_id, :integer
     t.column :associated_type, :string
   end
+
+  add_index :audits, [:auditable_type, :auditable_id], name: 'auditable_index'
 end

--- a/test/upgrade_generator_test.rb
+++ b/test/upgrade_generator_test.rb
@@ -79,6 +79,16 @@ class UpgradeGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "should add 'version' to auditable_index" do
+    load_schema 6
+
+    run_generator %w(upgrade)
+
+    assert_migration "db/migrate/add_version_to_auditable_index.rb" do |content|
+      assert_match(/add_index :audits, \[:auditable_type, :auditable_id, :version\]/, content)
+    end
+  end
+
   test "generate migration with correct AR migration parent" do
     load_schema 1
 


### PR DESCRIPTION
This will optimize:
- two scopes from https://github.com/collectiveidea/audited/blob/c48893a680f23d27f7e255dfec2af91e7a00e350/lib/audited/audit.rb#L55-L56
as they always will be used with `auditable_id` and `auditable_type` (like in `user.audits.from_version(100)`), so new index will be used to speed this up;
- and here https://github.com/collectiveidea/audited/blob/c48893a680f23d27f7e255dfec2af91e7a00e350/lib/audited/audit.rb#L174 Notice also, that now no auditable object will be loaded in this line

Probably, this index should be a `UNIQUE` index, but there are possible race conditions, at least at previously mentioned line.

**Simple data for testing**:
```sql
INSERT
INTO audits (auditable_id, auditable_type, version)
SELECT i % 1000 + 1, 'User', random() * 1000
FROM generate_series(1, 10000000) AS i;
```

**With old index**:
```sql
explain analyze select max(version) from audits where auditable_id = 12 and auditable_type = 'User'

Aggregate  (cost=16718.01..16718.02 rows=1 width=4) (actual time=49.106..49.107 rows=1 loops=1)
  ->  Index Scan using auditable_index on audits  (cost=0.43..16694.02 rows=9598 width=4) (actual time=1.541..47.316 rows=10000 loops=1)
        Index Cond: (((auditable_type)::text = 'User'::text) AND (auditable_id = 12))
Planning time: 0.190 ms
Execution time: 49.131 ms
```

**With new index**:
```sql
explain analyze select max(version) from audits where auditable_id = 525 and auditable_type = 'User'

    ->  Limit  (cost=0.43..1.36 rows=1 width=4) (actual time=0.064..0.064 rows=1 loops=1)
          ->  Index Only Scan Backward using auditable_index on audits  (cost=0.43..8997.91 rows=9735 width=4) (actual time=0.063..0.063 rows=1 loops=1)
                Index Cond: ((auditable_type = 'User'::text) AND (auditable_id = 525) AND (version IS NOT NULL))
                Heap Fetches: 1
Planning time: 2.660 ms
Execution time: 0.082 ms
```

So, 3 orders of magnitude faster.

Closes #189