### PR TITLE
Ensure enum changes are stored consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Changed
 
 Fixed
 
-- None
+- Ensure enum changes are stored consistently
+  [#429](https://github.com/collectiveidea/audited/pull/429)
 
 ## 4.7.0 (2018-03-14)
 

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -7,6 +7,7 @@ module Models
       audited except: :password
       attribute :non_column_attr if Rails.version >= '5.1'
       attr_protected :logins if respond_to?(:attr_protected)
+      enum status: { active: 0, reliable: 1, banned: 2 }
 
       def name=(val)
         write_attribute(:name, CGI.escapeHTML(val))

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define do
     t.column :username, :string
     t.column :password, :string
     t.column :activated, :boolean
+    t.column :status, :integer, default: 0
     t.column :suspended_at, :datetime
     t.column :logins, :integer, default: 0
     t.column :created_at, :datetime


### PR DESCRIPTION
```ruby
enum status: { new_status: "New", active: "In progress", complete: "Complete" }
```
Currently, when record is saved or destroyed, their audits contain enum values ("New", "In progress" or "Complete"). So I fixed "update" audits to store enum values as well for consistency. Also storing enum values (but not keys) allows to easily change enum key namings in future without changing existing audits. 

Fixes #202 
Fixes #214 
Fixes #412