### PR TITLE
Refactor install migration for better readability

### DIFF
--- a/lib/generators/audited/templates/install.rb
+++ b/lib/generators/audited/templates/install.rb
@@ -1,16 +1,13 @@
 class <%= migration_class_name %> < <%= migration_parent %>
   def change
     create_table :audits do |t|
-      t.belongs_to :auditable, polymorphic: true, index: false
-      t.index [:auditable_type, :auditable_id, :version],
-              name: :index_audits_on_auditable_and_version
+      t.references :auditable, polymorphic: true, index: false
 
       t.references :associated, polymorphic: true,
-                                index: { name: :index_audits_on_associated }
+                                index: { name: 'associated_index' }
 
       t.references :user, type: :<%= options[:audited_user_id_column_type] %>,
-                          polymorphic: true,
-                          index: { name: :index_audits_on_user }
+                          polymorphic: true, index: { name: 'user_index' }
 
       t.string :username
       t.string :action
@@ -18,8 +15,12 @@ class <%= migration_class_name %> < <%= migration_parent %>
       t.integer :version, default: 0
       t.string :comment
       t.string :remote_address
-      t.string :request_uuid, index: true
-      t.datetime :created_at, index: true
+      t.string :request_uuid
+      t.datetime :created_at
+
+      t.index [:auditable_type, :auditable_id, :version], name: 'auditable_index'
+      t.index :request_uuid
+      t.index :created_at
     end
   end
 end


### PR DESCRIPTION
Notable changes :
- removed `:force => true` (now the migration will fail if a table named `audits` already exists)
- renamed indexes on polymorphic association fields : `index_audits_on_assocation` to avoid collision with already existing indexes (particularly `user_index`, too general)
- changed the default `id` column type for polymorphic association on Rails 5.1+, `bigint` instead of `integer` (that is achieved automatically by `references` method on Rails 5.1+)

Other minor changes : 
- changed migration method : from `self.up`/`self.down` to `change` (best practice)
- use of Ruby 1.9 hash syntax
- moved columns type into method name