### PR TITLE
bump minimum ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.1
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 env:
   - DB=SQLITE
@@ -25,13 +23,6 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: ruby-head
-  exclude:
-    - rvm: 2.1
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/rails51.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/rails52.gemfile
   fast_finish: true
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@ For Rails 3, use gem version 3.0 or see the [3.0-stable branch](https://github.c
 
 Audited supports and is [tested against](http://travis-ci.org/collectiveidea/audited) the following Ruby versions:
 
-* 2.1.10
-* 2.2.9
-* 2.3.6
-* 2.4.3
-* 2.5.0
+* 2.3.7
+* 2.4.4
+* 2.5.1
 
 Audited may work just fine with a Ruby version not listed above, but we can't guarantee that it will. If you'd like to maintain a Ruby that isn't listed, please let us know with a [pull request](https://github.com/collectiveidea/audited/pulls).
 

--- a/audited.gemspec
+++ b/audited.gemspec
@@ -5,7 +5,6 @@ require "audited/version"
 Gem::Specification.new do |gem|
   gem.name        = 'audited'
   gem.version     = Audited::VERSION
-  gem.platform    = Gem::Platform::RUBY
 
   gem.authors     = ['Brandon Keepers', 'Kenneth Kalmer', 'Daniel Morrison', 'Brian Ryckbost', 'Steve Richert', 'Ryan Glover']
   gem.email       = 'info@collectiveidea.com'
@@ -15,6 +14,8 @@ Gem::Specification.new do |gem|
   gem.license     = 'MIT'
 
   gem.files         = `git ls-files`.split($\).reject{|f| f =~ /(\.gemspec)/ }
+
+  gem.required_ruby_version = '>= 2.3.0'
 
   gem.add_dependency 'activerecord', '>= 4.2', '< 5.2'
 


### PR DESCRIPTION
drop all EOL ruby versions ... enable us to use frozen strings magic comments and newer syntax

@tbrisker 