### PR TITLE
Add support for the final release of Rails 5.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -12,6 +12,6 @@ appraise 'rails51' do
 end
 
 appraise 'rails52' do
-  gem 'rails', '>= 5.2.0.rc1', '< 5.3'
+  gem 'rails', '>= 5.2.0', '< 5.3'
   gem 'mysql2', '~> 0.4.4'
 end

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Audited [![Build Status](https://secure.travis-ci.org/collectiveidea/audited.svg
 
 **Audited** (previously acts_as_audited) is an ORM extension that logs all changes to your models. Audited can also record who made those changes, save comments and associate models related to the changes.
 
-Audited currently (4.x) works with Rails 5.1, 5.0 and 4.2.
+Audited currently (4.x) works with Rails 5.2, 5.1, 5.0 and 4.2.
 
 For Rails 3, use gem version 3.0 or see the [3.0-stable branch](https://github.com/collectiveidea/audited/tree/3.0-stable).
 

--- a/audited.gemspec
+++ b/audited.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.3.0'
 
-  gem.add_dependency 'activerecord', '>= 4.2', '< 5.2'
+  gem.add_dependency 'activerecord', '>= 4.2', '< 5.3'
 
   gem.add_development_dependency 'appraisal'
-  gem.add_development_dependency 'rails', '>= 4.2', '< 5.2'
+  gem.add_development_dependency 'rails', '>= 4.2', '< 5.3'
   gem.add_development_dependency 'rspec-rails', '~> 3.5'
   gem.add_development_dependency 'single_cov'
 

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", ">= 5.2.0.rc1", "< 5.3"
+gem "rails", ">= 5.2.0", "< 5.3"
 gem "mysql2", "~> 0.4.4"
 
 gemspec name: "audited", path: "../"


### PR DESCRIPTION
- Fixes #440
- Bumped Rails version support on audited.gemspec
- Bumped Rails version support on gemfiles/rails52.gemfile
- Bumped Rails version support on Appraisals
- Added Rails 5.2 support to README