### PR TITLE
Backport 5.2 support to 4.7 stable

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -23,6 +23,6 @@ appraise 'rails51' do
 end
 
 appraise 'rails52' do
-  gem 'rails', '>= 5.2.0.rc1', '< 5.3'
+  gem 'rails', '>= 5.2.0', '< 5.3'
   gem 'mysql2', '~> 0.4.4'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,25 @@ Changed
 
 Fixed
 
+- None 
+
+## 4.7.1 (2018-04-10)
+
+Breaking changes
+
 - None
+
+Added
+
+- None
+
+Changed
+
+- None
+
+Fixed
+
+- Allow use with Rails 5.2 final
 
 ## 4.7.0 (2018-03-14)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Audited [![Build Status](https://secure.travis-ci.org/collectiveidea/audited.svg
 
 **Audited** (previously acts_as_audited) is an ORM extension that logs all changes to your models. Audited can also record who made those changes, save comments and associate models related to the changes.
 
-Audited currently (4.x) works with Rails 5.1, 5.0 and 4.2. It may work with 4.1 and 4.0, but this is not guaranteed.
+Audited currently (4.x) works with Rails 5.2, 5.1, 5.0 and 4.2. It may work with 4.1 and 4.0, but this is not guaranteed.
 
 For Rails 3, use gem version 3.0 or see the [3.0-stable branch](https://github.com/collectiveidea/audited/tree/3.0-stable).
 

--- a/audited.gemspec
+++ b/audited.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($\).reject{|f| f =~ /(\.gemspec)/ }
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'activerecord', '>= 4.0', '< 5.2'
+  gem.add_dependency 'activerecord', '>= 4.0', '< 5.3'
 
   gem.add_development_dependency 'appraisal'
-  gem.add_development_dependency 'rails', '>= 4.0', '< 5.2'
+  gem.add_development_dependency 'rails', '>= 4.0', '< 5.3'
   gem.add_development_dependency 'rspec-rails', '~> 3.5'
 
   # JRuby support for the test ENV

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", ">= 5.2.0.rc1", "< 5.3"
+gem "rails", ">= 5.2.0", "< 5.3"
 gem "mysql2", "~> 0.4.4"
 
 gemspec name: "audited", path: "../"

--- a/lib/audited/version.rb
+++ b/lib/audited/version.rb
@@ -1,3 +1,3 @@
 module Audited
-  VERSION = "4.7.0"
+  VERSION = "4.7.1"
 end


### PR DESCRIPTION
@danielmorrison - This backports permitting rails 5.2 on audited 4.7 stable branch, can you tag and release 4.7.1 please? (was requested in https://github.com/collectiveidea/audited/pull/441#issuecomment-380168068) 
The other changes in master branch will only be released in 5.0 version since they contain breaking changes.