### PR TITLE
allow private methods on audited condition

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -285,9 +285,8 @@ module Audited
 
       def run_conditional_check(condition, matching: true)
         return true if condition.blank?
-
         return condition.call(self) == matching if condition.respond_to?(:call)
-        return send(condition) == matching if respond_to?(condition.to_sym)
+        return send(condition) == matching if respond_to?(condition.to_sym, true)
 
         true
       end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -22,6 +22,24 @@ describe Audited::Auditor do
     context "should be configurable which conditions are audited" do
       subject { ConditionalCompany.new.send(:auditing_enabled) }
 
+      context "when condition method is private" do
+        subject { ConditionalPrivateCompany.new.send(:auditing_enabled) }
+
+        before do
+          class ConditionalPrivateCompany < ::ActiveRecord::Base
+            self.table_name = 'companies'
+
+            audited if: :foo?
+
+            private def foo?
+              true
+            end
+          end
+        end
+
+        it { is_expected.to be_truthy }
+      end
+
       context "when passing a method name" do
         before do
           class ConditionalCompany < ::ActiveRecord::Base


### PR DESCRIPTION
Adding `true`as a second parameter to include private methods on conditional verification.