### PR TITLE
include 4.7.1 changelog updates [ci skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ Fixed
 
 - None
 
+## 4.7.1 (2018-04-10)
+
+Breaking changes
+
+- None
+
+Added
+
+- None
+
+Changed
+
+- None
+
+Fixed
+
+- Allow use with Rails 5.2 final
+
 ## 4.7.0 (2018-03-14)
 
 Breaking changes


### PR DESCRIPTION
I noticed the 4.7.1 changes were missing from the Changelog.md on master. This PR adds them back.