### PR TITLE
Remove deprecation warning, remove method_missing

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -90,16 +90,6 @@ module Audited
     end
 
     module AuditedInstanceMethods
-      # Deprecate version attribute in favor of audit_version attribute – preparing for eventual removal.
-      def method_missing(method_name, *args, &block)
-        if method_name == :version
-          ActiveSupport::Deprecation.warn("`version` attribute has been changed to `audit_version`. This attribute will be removed.")
-          audit_version
-        else
-          super
-        end
-      end
-
       # Temporarily turns off auditing while saving.
       def save_without_auditing
         without_auditing { save }


### PR DESCRIPTION
The method_missing might interfere with other method_missing in the class, e.g. ActiveRecord::Delegation#method_missing
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/relation/delegation.rb#L111

I originally considered just defining the version method, but that was in the original PR, and it was decided not to do it.
https://github.com/collectiveidea/audited/pull/443#discussion_r180718047

I think the best way forward is just to remove the deprecation warning and to do a major version bump.