### PR TITLE
Adds redacted option

### DIFF
--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -25,6 +25,21 @@ module Models
       audited only: :password
     end
 
+    class UserRedactedPassword < ::ActiveRecord::Base
+      self.table_name = :users
+      audited redacted: :password
+    end
+
+    class UserMultipleRedactedAttributes < ::ActiveRecord::Base
+      self.table_name = :users
+      audited redacted: [:password, :ssn]
+    end
+
+    class UserRedactedPasswordCustomRedaction < ::ActiveRecord::Base
+      self.table_name = :users
+      audited redacted: :password, redaction_value: ["My", "Custom", "Value", 7]
+    end
+
     class CommentRequiredUser < ::ActiveRecord::Base
       self.table_name = :users
       audited comment_required: true

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define do
     t.column :created_at, :datetime
     t.column :updated_at, :datetime
     t.column :favourite_device, :string
+    t.column :ssn, :integer
   end
 
   create_table :companies do |t|


### PR DESCRIPTION
* In order to record that changes occurred, without storing sensitive
values, pass the `redacted` option.

* Redacted values default to `'[REDACTED]'` but can be customized with
the `redaction_value` option.

```
class User
    audited redacted: [:password, :ssn], redaction_value: SecureRandom.uuid
end
```

* A lot of this was based on the work done [here](https://github.com/collectiveidea/audited/pull/339).

* Resolves https://github.com/collectiveidea/audited/issues/475.