### PR TITLE
Support and test Rails 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,17 @@ gemfile:
   - gemfiles/rails50.gemfile
   - gemfiles/rails51.gemfile
   - gemfiles/rails52.gemfile
+  - gemfiles/rails60.gemfile
 matrix:
   include:
     - rvm: 2.3.7
       script: bundle exec rubocop --parallel
       env: DB=rubocop # make travis build display nicer
+  exclude:
+    - rvm: 2.3.7
+      gemfile: gemfiles/rails60.gemfile
+    - rvm: 2.4.4
+      gemfile: gemfiles/rails60.gemfile
   allow_failures:
     - rvm: ruby-head
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
+  - 2.6.3
   - ruby-head
 env:
   - DB=SQLITE
@@ -29,7 +30,7 @@ gemfile:
   - gemfiles/rails60.gemfile
 matrix:
   include:
-    - rvm: 2.3.7
+    - rvm: 2.6.3
       script: bundle exec rubocop --parallel
       env: DB=rubocop # make travis build display nicer
   exclude:
@@ -37,6 +38,10 @@ matrix:
       gemfile: gemfiles/rails60.gemfile
     - rvm: 2.4.4
       gemfile: gemfiles/rails60.gemfile
+    - rvm: 2.6.3
+      gemfile: gemfiles/rails42.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails42.gemfile
   allow_failures:
     - rvm: ruby-head
   fast_finish: true

--- a/Appraisals
+++ b/Appraisals
@@ -1,17 +1,38 @@
+# Include DB adapters matching the version requirements in
+# rails/activerecord/lib/active_record/connection_adapters/*adapter.rb
+
 appraise 'rails42' do
   gem 'rails', '~> 4.2.0'
   gem 'protected_attributes'
+  gem "mysql2", ">= 0.3.13", "< 0.6.0"
+  gem "pg", "~> 0.15"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 appraise 'rails50' do
   gem 'rails', '~> 5.0.0'
+  gem "mysql2", ">= 0.3.18", "< 0.6.0"
+  gem "pg", ">= 0.18", "< 2.0"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 appraise 'rails51' do
   gem 'rails', '~> 5.1.4'
+  gem "mysql2", ">= 0.3.18", "< 0.6.0"
+  gem "pg", ">= 0.18", "< 2.0"
+  gem "sqlite3", "~> 1.3.6"
 end
 
 appraise 'rails52' do
   gem 'rails', '>= 5.2.0', '< 5.3'
-  gem 'mysql2', '~> 0.4.4'
+  gem "mysql2", ">= 0.4.4", "< 0.6.0"
+  gem "pg", ">= 0.18", "< 2.0"
+  gem "sqlite3", "~> 1.3.6"
+end
+
+appraise 'rails60' do
+  gem 'rails', '>= 6.0.0.rc1', '< 6.1'
+  gem "mysql2", ">= 0.4.4"
+  gem "pg", ">= 0.18", "< 2.0"
+  gem "sqlite3", "~> 1.4"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Added
 
 - Add `update_with_comment_only` option to control audit creation with only comments
   [#327](https://github.com/collectiveidea/audited/pull/327)
+- Support for Rails 6.0 and Ruby 2.6
+  [#494](https://github.com/collectiveidea/audited/pull/494)
 
 Changed
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Audited [![Build Status](https://secure.travis-ci.org/collectiveidea/audited.svg
 
 **Audited** (previously acts_as_audited) is an ORM extension that logs all changes to your models. Audited can also record who made those changes, save comments and associate models related to the changes.
 
-Audited currently (4.x) works with Rails 5.2, 5.1, 5.0 and 4.2.
+Audited currently (4.x) works with Rails 6.0, 5.2, 5.1, 5.0 and 4.2.
 
 For Rails 3, use gem version 3.0 or see the [3.0-stable branch](https://github.com/collectiveidea/audited/tree/3.0-stable).
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ By default, whenever a user is created, updated or destroyed, a new audit is cre
 ```ruby
 user = User.create!(name: "Steve")
 user.audits.count # => 1
-user.update_attributes!(name: "Ryan")
+user.update!(name: "Ryan")
 user.audits.count # => 2
 user.destroy
 user.audits.count # => 3
@@ -74,7 +74,7 @@ user.audits.count # => 3
 Audits contain information regarding what action was taken on the model and what changes were made.
 
 ```ruby
-user.update_attributes!(name: "Ryan")
+user.update!(name: "Ryan")
 audit = user.audits.last
 audit.action # => "update"
 audit.audited_changes # => {"name"=>["Steve", "Ryan"]}
@@ -128,7 +128,7 @@ end
 You can attach comments to each audit using an `audit_comment` attribute on your model.
 
 ```ruby
-user.update_attributes!(name: "Ryan", audit_comment: "Changing name, just because")
+user.update!(name: "Ryan", audit_comment: "Changing name, just because")
 user.audits.last.comment # => "Changing name, just because"
 ```
 
@@ -169,7 +169,7 @@ Whenever an object is updated or destroyed, extra audits are combined with newer
 ```ruby
 user = User.create!(name: "Steve")
 user.audits.count # => 1
-user.update_attributes!(name: "Ryan")
+user.update!(name: "Ryan")
 user.audits.count # => 2
 user.destroy
 user.audits.count # => 2
@@ -199,7 +199,7 @@ Outside of a request, Audited can still record the user with the `as_user` metho
 
 ```ruby
 Audited.audit_class.as_user(User.find(1)) do
-  post.update_attributes!(title: "Hello, world!")
+  post.update!(title: "Hello, world!")
 end
 post.audits.last.user # => #<User id: 1>
 ```
@@ -256,7 +256,7 @@ Now, when an audit is created for a user, that user's company is also saved alon
 ```ruby
 company = Company.create!(name: "Collective Idea")
 user = company.users.create!(name: "Steve")
-user.update_attribute!(name: "Steve Richert")
+user.update!(name: "Steve Richert")
 user.audits.last.associated # => #<Company name: "Collective Idea">
 company.associated_audits.last.auditable # => #<User name: "Steve Richert">
 ```

--- a/audited.gemspec
+++ b/audited.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.3.0'
 
-  gem.add_dependency 'activerecord', '>= 4.2', '< 5.3'
+  gem.add_dependency 'activerecord', '>= 4.2', '< 6.1'
 
   gem.add_development_dependency 'appraisal'
-  gem.add_development_dependency 'rails', '>= 4.2', '< 5.3'
+  gem.add_development_dependency 'rails', '>= 4.2', '< 6.1'
   gem.add_development_dependency 'rubocop', '~> 0.54.0'
   gem.add_development_dependency 'rspec-rails', '~> 3.5'
   gem.add_development_dependency 'single_cov'
@@ -31,8 +31,8 @@ Gem::Specification.new do |gem|
     gem.add_development_dependency 'activerecord-jdbcpostgresql-adapter', '~> 1.3'
     gem.add_development_dependency 'activerecord-jdbcmysql-adapter', '~> 1.3'
   else
-    gem.add_development_dependency 'sqlite3', '~> 1.3.6'
-    gem.add_development_dependency 'mysql2', '~> 0.3.20'
-    gem.add_development_dependency 'pg', '~> 0.18'
+    gem.add_development_dependency 'sqlite3', '~> 1.3'
+    gem.add_development_dependency 'mysql2', '>= 0.3.20'
+    gem.add_development_dependency 'pg', '>= 0.18', '< 2.0'
   end
 end

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -4,5 +4,8 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
 gem "protected_attributes"
+gem "mysql2", ">= 0.3.13", "< 0.6.0"
+gem "pg", "~> 0.15"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec name: "audited", path: "../"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -3,5 +3,8 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
+gem "mysql2", ">= 0.3.18", "< 0.6.0"
+gem "pg", ">= 0.18", "< 2.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec name: "audited", path: "../"

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -3,6 +3,8 @@
 source "https://rubygems.org"
 
 gem "rails", ">= 5.2.0", "< 5.3"
-gem "mysql2", "~> 0.4.4"
+gem "mysql2", ">= 0.4.4", "< 0.6.0"
+gem "pg", ">= 0.18", "< 2.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec name: "audited", path: "../"

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.1.4"
-gem "mysql2", ">= 0.3.18", "< 0.6.0"
+gem "rails", ">= 6.0.0.rc1", "< 6.1"
+gem "mysql2", ">= 0.4.4"
 gem "pg", ">= 0.18", "< 2.0"
-gem "sqlite3", "~> 1.3.6"
+gem "sqlite3", "~> 1.4"
 
 gemspec name: "audited", path: "../"

--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -97,7 +97,7 @@ module Audited
         auditable_type.constantize.create!(audited_changes)
       when 'update'
         # changes back attributes
-        auditable.update_attributes!(audited_changes.transform_values(&:first))
+        auditable.update!(audited_changes.transform_values(&:first))
       else
         raise StandardError, "invalid action given #{action}"
       end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -325,19 +325,19 @@ describe Audited::Auditor do
     end
 
     it "should set the action to 'update'" do
-      @user.update_attributes name: 'Changed'
+      @user.update! name: 'Changed'
       expect(@user.audits.last.action).to eq('update')
       expect(Audited::Audit.updates.order(:id).last).to eq(@user.audits.last)
       expect(@user.audits.updates.last).to eq(@user.audits.last)
     end
 
     it "should store the changed attributes" do
-      @user.update_attributes name: 'Changed'
+      @user.update! name: 'Changed'
       expect(@user.audits.last.audited_changes).to eq({ 'name' => ['Brandon', 'Changed'] })
     end
 
     it "should store changed enum values" do
-      @user.update_attributes status: 1
+      @user.update! status: 1
       expect(@user.audits.last.audited_changes["status"]).to eq([0, 1])
     end
 
@@ -348,12 +348,12 @@ describe Audited::Auditor do
     it "should not save an audit if only specified on create/destroy" do
       on_create_destroy = Models::ActiveRecord::OnCreateDestroy.create( name: 'Bart' )
       expect {
-        on_create_destroy.update_attributes name: 'Changed'
+        on_create_destroy.update! name: 'Changed'
       }.to_not change( Audited::Audit, :count )
     end
 
     it "should not save an audit if the value doesn't change after type casting" do
-      @user.update_attributes! logins: 0, activated: true
+      @user.update! logins: 0, activated: true
       expect { @user.update_attribute :logins, '0' }.to_not change( Audited::Audit, :count )
       expect { @user.update_attribute :activated, 1 }.to_not change( Audited::Audit, :count )
       expect { @user.update_attribute :activated, '1' }.to_not change( Audited::Audit, :count )
@@ -508,13 +508,13 @@ describe Audited::Auditor do
     it "should delete old extra audits after introducing limit" do
       stub_global_max_audits(nil) do
         user = Models::ActiveRecord::User.create!(name: 'Brandon', username: 'brandon')
-        user.update_attributes(name: 'Foobar')
-        user.update_attributes(name: 'Awesome', username: 'keepers')
-        user.update_attributes(activated: true)
+        user.update!(name: 'Foobar')
+        user.update!(name: 'Awesome', username: 'keepers')
+        user.update!(activated: true)
 
         Audited.max_audits = 3
         Models::ActiveRecord::User.send(:normalize_audited_options)
-        user.update_attributes(favourite_device: 'Android Phone')
+        user.update!(favourite_device: 'Android Phone')
         audits = user.audits
 
         expect(audits.count).to eq(3)
@@ -565,8 +565,8 @@ describe Audited::Auditor do
 
     it "should set the attributes for each revision" do
       u = Models::ActiveRecord::User.create(name: 'Brandon', username: 'brandon')
-      u.update_attributes name: 'Foobar'
-      u.update_attributes name: 'Awesome', username: 'keepers'
+      u.update! name: 'Foobar'
+      u.update! name: 'Awesome', username: 'keepers'
 
       expect(u.revisions.size).to eql(3)
 
@@ -582,8 +582,8 @@ describe Audited::Auditor do
 
     it "access to only recent revisions" do
       u = Models::ActiveRecord::User.create(name: 'Brandon', username: 'brandon')
-      u.update_attributes name: 'Foobar'
-      u.update_attributes name: 'Awesome', username: 'keepers'
+      u.update! name: 'Foobar'
+      u.update! name: 'Awesome', username: 'keepers'
 
       expect(u.revisions(2).size).to eq(2)
 
@@ -600,7 +600,7 @@ describe Audited::Auditor do
     end
 
     it "should ignore attributes that have been deleted" do
-      user.audits.last.update_attributes audited_changes: {old_attribute: 'old value'}
+      user.audits.last.update! audited_changes: {old_attribute: 'old value'}
       expect { user.revisions }.to_not raise_error
     end
   end
@@ -649,8 +649,8 @@ describe Audited::Auditor do
 
     it "should set the attributes for each revision" do
       u = Models::ActiveRecord::User.create(name: 'Brandon', username: 'brandon')
-      u.update_attributes name: 'Foobar'
-      u.update_attributes name: 'Awesome', username: 'keepers'
+      u.update! name: 'Foobar'
+      u.update! name: 'Awesome', username: 'keepers'
 
       expect(u.revision(3).name).to eq('Awesome')
       expect(u.revision(3).username).to eq('keepers')
@@ -712,7 +712,7 @@ describe Audited::Auditor do
       audit = user.audits.first
       audit.created_at = 1.hour.ago
       audit.save!
-      user.update_attributes name: 'updated'
+      user.update! name: 'updated'
       expect(user.revision_at( 2.minutes.ago ).audit_version).to eq(1)
     end
 
@@ -804,7 +804,7 @@ describe Audited::Auditor do
       Audited.auditing_enabled = true
       expect(Models::ActiveRecord::User.auditing_enabled).to eq(true)
 
-      user.update_attributes(name: 'Test')
+      user.update!(name: 'Test')
       expect(user.audits.count).to eq(1)
     end
   end
@@ -842,21 +842,21 @@ describe Audited::Auditor do
       let( :on_destroy_user ) { Models::ActiveRecord::OnDestroyCommentRequiredUser.create }
 
       it "should not validate when audit_comment is not supplied" do
-        expect(user.update_attributes(name: 'Test')).to eq(false)
+        expect(user.update(name: 'Test')).to eq(false)
       end
 
       it "should validate when audit_comment is not supplied, and updating is not being audited" do
-        expect(on_create_user.update_attributes(name: 'Test')).to eq(true)
-        expect(on_destroy_user.update_attributes(name: 'Test')).to eq(true)
+        expect(on_create_user.update(name: 'Test')).to eq(true)
+        expect(on_destroy_user.update(name: 'Test')).to eq(true)
       end
 
       it "should validate when audit_comment is supplied" do
-        expect(user.update_attributes(name: 'Test', audit_comment: 'Update')).to eq(true)
+        expect(user.update(name: 'Test', audit_comment: 'Update')).to eq(true)
       end
 
       it "should validate when audit_comment is not supplied, and auditing is disabled" do
         Models::ActiveRecord::CommentRequiredUser.disable_auditing
-        expect(user.update_attributes(name: 'Test')).to eq(true)
+        expect(user.update(name: 'Test')).to eq(true)
         Models::ActiveRecord::CommentRequiredUser.enable_auditing
       end
     end
@@ -920,7 +920,7 @@ describe Audited::Auditor do
     it "should record user objects" do
       Models::ActiveRecord::Company.audit_as( user ) do
         company = Models::ActiveRecord::Company.create name: 'The auditors'
-        company.update_attributes name: 'The Auditors'
+        company.update! name: 'The Auditors'
 
         company.audits.each do |audit|
           expect(audit.user).to eq(user)
@@ -931,7 +931,7 @@ describe Audited::Auditor do
     it "should record usernames" do
       Models::ActiveRecord::Company.audit_as( user.name ) do
         company = Models::ActiveRecord::Company.create name: 'The auditors'
-        company.update_attributes name: 'The Auditors'
+        company.update! name: 'The Auditors'
 
         company.audits.each do |audit|
           expect(audit.user).to eq(user.name)
@@ -966,7 +966,7 @@ describe Audited::Auditor do
       expect(company.type).to eq("Models::ActiveRecord::Company::STICompany")
       expect {
         Models::ActiveRecord::Company.auditing_enabled = false
-        company.update_attributes name: 'STI auditors'
+        company.update! name: 'STI auditors'
         Models::ActiveRecord::Company.auditing_enabled = true
       }.to_not change( Audited::Audit, :count )
     end

--- a/spec/audited/sweeper_spec.rb
+++ b/spec/audited/sweeper_spec.rb
@@ -13,7 +13,7 @@ class AuditsController < ActionController::Base
   end
 
   def update
-    current_user.update_attributes(password: 'foo')
+    current_user.update!(password: 'foo')
     head :ok
   end
 

--- a/spec/rails_app/app/controllers/application_controller.rb
+++ b/spec/rails_app/app/controllers/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < ActionController::Base
+end

--- a/spec/rails_app/config/database.yml
+++ b/spec/rails_app/config/database.yml
@@ -19,6 +19,7 @@ mysql: &MYSQL
   username: root
   password:
   database: audited_test
+  charset: utf8
 
 test:
   <<: *<%= ENV['DB'] || 'SQLITE3MEM' %>

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -15,7 +15,7 @@ begin
       db_config[:configure_connection] = false
     end
     adapter = ActiveRecord::Base.send("#{db_type}_connection", db_config)
-    adapter.recreate_database db_name
+    adapter.recreate_database db_name, db_config.slice('charset').symbolize_keys
     adapter.disconnect!
   end
 rescue => e


### PR DESCRIPTION
Includes Ruby 2.6 in the test matrix, fixes a deprecation and a couple of small issues that prevented tests running correctly on Rails 6.0.

Fixes #488