### PR TITLE
Allow for Audting to be enabled temporarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Breaking changes
 
 Added
 
+- Add `with_auditing` methods to enable temporarily
+  [#502](https://github.com/collectiveidea/audited/pull/502)
 - Add `update_with_comment_only` option to control audit creation with only comments
   [#327](https://github.com/collectiveidea/audited/pull/327)
 - Support for Rails 6.0 and Ruby 2.6

--- a/README.md
+++ b/README.md
@@ -332,6 +332,23 @@ To disable auditing on all models:
 Audited.auditing_enabled = false
 ```
 
+If you have auditing disabled by default on your model you can enable auditing
+temporarily.
+
+```ruby
+User.auditing_enabled = false
+@user.save_with_auditing
+```
+
+or:
+
+```ruby
+User.auditing_enabled = false
+@user.with_auditing do
+  @user.save
+end
+```
+
 ### Custom `Audit` model
 
 If you want to extend or modify the audit model, create a new class that

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -115,6 +115,21 @@ module Audited
         self.class.without_auditing(&block)
       end
 
+      # Temporarily turns on auditing while saving.
+      def save_with_auditing
+        with_auditing { save }
+      end
+
+      # Executes the block with the auditing callbacks enabled.
+      #
+      #   @foo.with_auditing do
+      #     @foo.save
+      #   end
+      #
+      def with_auditing(&block)
+        self.class.with_auditing(&block)
+      end
+
       # Gets an array of the revisions available
       #
       #   user.revisions.each do |revision|
@@ -361,6 +376,20 @@ module Audited
         yield
       ensure
         enable_auditing if auditing_was_enabled
+      end
+
+      # Executes the block with auditing enabled.
+      #
+      #   Foo.with_auditing do
+      #     @foo.save
+      #   end
+      #
+      def with_auditing
+        auditing_was_enabled = auditing_enabled
+        enable_auditing
+        yield
+      ensure
+        disable_auditing unless auditing_was_enabled
       end
 
       def disable_auditing


### PR DESCRIPTION
Some models I only want auditing in certain conditions, this allows me to disable it by default and turn it on only when needed. 