### PR TITLE
Enable MySQL service on new Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   - DB=SQLITE
   - DB=POSTGRES
   - DB=MYSQL
+services:
+  - mysql
 addons:
   postgresql: "9.4"
 before_install:


### PR DESCRIPTION
The Travis CI default image has changed from the Trusty to Xenial image,
breaking builds on master as the MySQL server isn't running by
default[1].

[1]https://blog.travis-ci.com/2018-11-08-xenial-release