### PR TITLE
Avoid extra query by setting version to 1 when action is create

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -131,7 +131,7 @@ module Audited
     # by +user+. This method is hopefully threadsafe, making it ideal
     # for background operations that require audit information.
     def self.as_user(user)
-      last_audited_user = ::Audited.store[:audited_user] 
+      last_audited_user = ::Audited.store[:audited_user]
       ::Audited.store[:audited_user] = user
       yield
     ensure
@@ -168,8 +168,12 @@ module Audited
     private
 
     def set_version_number
-      max = self.class.auditable_finder(auditable_id, auditable_type).maximum(:version) || 0
-      self.version = max + 1
+      if action == 'create'
+        self.version = 1
+      else
+        max = self.class.auditable_finder(auditable_id, auditable_type).maximum(:version) || 0
+        self.version = max + 1
+      end
     end
 
     def set_audit_user


### PR DESCRIPTION
Thank you for your work on this gem. Please advise on any way I can improve this PR.

This change optimizes `set_version_number` by automatically setting version to 1 on create, helping performance in particular in cases of bulk inserts.