### PR TITLE
PF-576-2-update-5-1

### DIFF
--- a/lib/audited/sweeper.rb
+++ b/lib/audited/sweeper.rb
@@ -56,6 +56,6 @@ end
 
 if defined?(ActionController) && defined?(ActionController::Base)
   ActionController::Base.class_eval do
-    around_filter Audited::Sweeper.instance
+    around_action Audited::Sweeper.instance
   end
 end


### PR DESCRIPTION
Deares Reviewer

rails 5.1 removed the old method

rake aborted!
NoMethodError: undefined method `around_filter' for ActionController::Base:Class
Did you mean?  around_action
/usr/local/bundle/bundler/gems/audited-1af1a5b05f46/lib/audited/sweeper.rb:64:in `block in <main>'

Becker