### PR TITLE
Follow Rails autoloading conventions

### DIFF
--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -30,3 +30,4 @@ require 'audited/audit'
 ::ActiveRecord::Base.send :include, Audited::Auditor
 
 require 'audited/sweeper'
+require 'audited/railtie'

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -27,7 +27,9 @@ end
 require 'audited/auditor'
 require 'audited/audit'
 
-::ActiveRecord::Base.send :include, Audited::Auditor
+ActiveSupport.on_load :active_record do
+  include Audited::Auditor
+end
 
 require 'audited/sweeper'
 require 'audited/railtie'

--- a/lib/audited/railtie.rb
+++ b/lib/audited/railtie.rb
@@ -1,0 +1,14 @@
+module Audited
+  class Railtie < Rails::Railtie
+    initializer "audited.sweeper" do
+      ActiveSupport.on_load(:action_controller) do
+        if defined?(ActionController::Base)
+          ActionController::Base.around_action Audited::Sweeper.new
+        end
+        if defined?(ActionController::API)
+          ActionController::API.around_action Audited::Sweeper.new
+        end
+      end
+    end
+  end
+end

--- a/lib/audited/sweeper.rb
+++ b/lib/audited/sweeper.rb
@@ -38,12 +38,3 @@ module Audited
     end
   end
 end
-
-ActiveSupport.on_load(:action_controller) do
-  if defined?(ActionController::Base)
-    ActionController::Base.around_action Audited::Sweeper.new
-  end
-  if defined?(ActionController::API)
-    ActionController::API.around_action Audited::Sweeper.new
-  end
-end

--- a/spec/audited/sweeper_spec.rb
+++ b/spec/audited/sweeper_spec.rb
@@ -30,6 +30,7 @@ describe AuditsController do
   render_views
 
   before do
+    Audited::Railtie.initializers.each(&:run)
     Audited.current_user_method = :current_user
   end
 


### PR DESCRIPTION
Depends on #530, because it won't pass specs without.

Thank you for this excellent gem, which we're using happily in production.

I encountered a conflict between `audited` and another gem which I believe is caused by the way audited hooks into Rails core classes. A minimal app displaying the behaviour is here: https://github.com/duncanjbrown/audited-bug. The behaviour is outlined on a rubyonrails-talk thread here: https://discuss.rubyonrails.org/t/understanding-a-conflict-between-two-activesupport-on-load-calls/74836.

Where an `on_load` reference is required to a non-ActiveSupport class (such as `ActionController::API`), wrapping the initialization code in a proper `railtie` prevents the weirdness I see in the above app. As far as I can tell this is the correct way to inject this code and it doesn't seem to break `audited`, which is why I'm submitting this PR.

While investigating this I learned that the current guidance (https://edgeguides.rubyonrails.org/engines.html#avoid-loading-rails-frameworks) it is best practice to extend core classes by hooking into ActiveSupport.on_load hooks, so this PR includes a change to the way `audited` does that, too.
