### PR TITLE
Fix Rails 6.1 deprecations

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -171,7 +171,7 @@ module Audited
       if action == 'create'
         self.version = 1
       else
-        max = self.class.auditable_finder(auditable_id, auditable_type).maximum(:version) || 0
+        max = self.class.unscoped.auditable_finder(auditable_id, auditable_type).maximum(:version) || 0
         self.version = max + 1
       end
     end

--- a/spec/audited/sweeper_spec.rb
+++ b/spec/audited/sweeper_spec.rb
@@ -101,7 +101,8 @@ describe AuditsController do
       controller.send(:current_user=, user)
 
       expect {
-        put :update, Rails::VERSION::MAJOR == 4 ? {id: 123} : {params: {id: 123}}
+        params = Rails::VERSION::MAJOR == 4 ? {id: 123} : {params: {id: 123}}
+        put :update, **params
       }.to_not change( Audited::Audit, :count )
     end
   end

--- a/spec/rails_app/app/assets/config/manifest.js
+++ b/spec/rails_app/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link application.js
+//= link application.css


### PR DESCRIPTION
**Description ***

Fixes a Rails 6 warning
> DEPRECATION WARNING: Class level methods will no longer inherit scoping from `create` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `Audit.default_scoped`.

*note:* It might possibly make sense to use `default_scoped` instead of `unscoped` but I feel that `unscoped` makes more sense since versioning should include records that might not be returned by `default_scoped`