### PR TITLE
Remove rc from Rails 6 gemfile

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -31,7 +31,7 @@ appraise 'rails52' do
 end
 
 appraise 'rails60' do
-  gem 'rails', '>= 6.0.0.rc1', '< 6.1'
+  gem 'rails', '>= 6.0.0', '< 6.1'
   gem "mysql2", ">= 0.4.4"
   gem "pg", ">= 0.18", "< 2.0"
   gem "sqlite3", "~> 1.4"

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", ">= 6.0.0.rc1", "< 6.1"
+gem "rails", ">= 6.0.0", "< 6.1"
 gem "mysql2", ">= 0.4.4"
 gem "pg", ">= 0.18", "< 2.0"
 gem "sqlite3", "~> 1.4"


### PR DESCRIPTION
This makes it a little bit clearer that it supports Rails 6.