### PR TITLE
Improved custom audit user section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,16 @@ end
 post.audits.last.user # => 'console-user-username'
 ```
 
+If you want to set a specific user as the auditor of the commands in a CLI environment, whether that is a string or an ActiveRecord object, you can use the following command:
+
+```rb
+Audited.store[:audited_user] = "username"
+
+# or
+
+Audited.store[:audited_user] = User.find(1)
+```
+
 ### Associated Audits
 
 Sometimes it's useful to associate an audit with a model other than the one being changed. For instance, given the following models:


### PR DESCRIPTION
I don't know if the `Audited.store` is meant to be used like that, but I spent a couple of hours trying to accomplish that today, so I thought it would be good to document it for future users trying to do the same thing.

To elaborate a little bit further, I needed to set a specific user as the auditor of all the commands in a console session. I patched the rails console to add an authentication with devise when opened, so that command comes right after a successful user login in the console.