### PR TITLE
Fix flaky test which would fail in certain timezones

### DIFF
--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -174,7 +174,7 @@ describe Audited::Audit do
       it "uses created at" do
         Audited::Audit.delete_all
         audit = Models::ActiveRecord::User.create(name: "John").audits.last
-        audit.update_columns(created_at: Time.parse('2018-01-01'))
+        audit.update_columns(created_at: Time.zone.parse('2018-01-01'))
         expect(Audited::Audit.collection_cache_key).to match(/-20180101\d+$/)
       end
     else


### PR DESCRIPTION
I'm currently in Singapore (whose timezone is UTC+8), and this test was constantly failing:

```
Failures:

  1) Audited::Audit.collection_cache_key uses created at
     Failure/Error: expect(Audited::Audit.collection_cache_key).to match(/-20180101\d+$/)

       expected "audited/audits/query-1ae402d409ee3a828c0f94e5cd171ef7-1-20171231160000000000" to match /-20180101\d+$/
       Diff:
       @@ -1 +1 @@
       -/-20180101\d+$/
       +"audited/audits/query-1ae402d409ee3a828c0f94e5cd171ef7-1-20171231160000000000"

     # ./spec/audited/audit_spec.rb:178:in `block (3 levels) in <top (required)>'
```

Without using `Time.zone.parse`, the `Time.parse` method will default to the local timezone, which would cause an error in this specific case (4PM UTC is 12AM SGT).