### PR TITLE
Fix Rails 6 and Rails 6.1 Builds

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -31,7 +31,7 @@ appraise 'rails52' do
 end
 
 appraise 'rails60' do
-  gem 'rails', '>= 6.0.0.rc1', '< 6.1'
+  gem 'rails', '>= 6.0.0', '< 6.1'
   gem "mysql2", ">= 0.4.4"
   gem "pg", ">= 0.18", "< 2.0"
   gem "sqlite3", "~> 1.4"

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", ">= 6.0.0.rc1", "< 6.1"
+gem "rails", ">= 6.0.0", "< 6.1"
 gem "mysql2", ">= 0.4.4"
 gem "pg", ">= 0.18", "< 2.0"
 gem "sqlite3", "~> 1.4"

--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -16,7 +16,7 @@ module Audited
   class YAMLIfTextColumnType
     class << self
       def load(obj)
-        if Audited.audit_class.columns_hash["audited_changes"].type.to_s == "text"
+        if text_column?
           ActiveRecord::Coders::YAMLColumn.new(Object).load(obj)
         else
           obj
@@ -24,11 +24,15 @@ module Audited
       end
 
       def dump(obj)
-        if Audited.audit_class.columns_hash["audited_changes"].type.to_s == "text"
+        if text_column?
           ActiveRecord::Coders::YAMLColumn.new(Object).dump(obj)
         else
           obj
         end
+      end
+
+      def text_column?
+        Audited.audit_class.columns_hash["audited_changes"].type.to_s == "text"
       end
     end
   end

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -62,7 +62,7 @@ describe Audited::Audit do
     end
 
     it "does not unserialize from binary columns" do
-      allow(Audited.audit_class.columns_hash["audited_changes"]).to receive(:type).and_return("foo")
+      allow(Audited::YAMLIfTextColumnType).to receive(:text_column?).and_return(false)
       audit.audited_changes = {foo: "bar"}
       expect(audit.audited_changes).to eq "{:foo=>\"bar\"}"
     end


### PR DESCRIPTION
### WHY

- Fixes the gem spec for Rails 6 so it does not pull in Rails 6.1 rc builds
- Fixes the build in Rails 6.1 by not mocking the frozen object.

This should unlock at least the following two PRs #554 and #555 