### PR TITLE
Don't redact values when there are no changes to save

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -254,6 +254,7 @@ module Audited
 
       def redact_values(filtered_changes)
         [audited_options[:redacted]].flatten.compact.each do |option|
+          next unless filtered_changes.key?(option.to_s)
           changes = filtered_changes[option.to_s]
           new_value = audited_options[:redaction_value] || REDACTED
           if changes.is_a? Array

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -245,6 +245,12 @@ describe Audited::Auditor do
       expect(user.audits.last.audited_changes['password']).to eq(["My", "Custom", "Value", 7])
     end
 
+    it "should not redact columns with no changes to save" do
+      user = Models::ActiveRecord::UserRedactedPassword.create(password: "password")
+      user.update!(status: :reliable)
+      expect(user.audits.last.audited_changes).not_to have_key :password
+    end
+
     if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
       describe "'json' and 'jsonb' audited_changes column type" do
         let(:migrations_path) { SPEC_ROOT.join("support/active_record/postgres") }


### PR DESCRIPTION
The redaction functionality introduced in https://github.com/collectiveidea/audited/pull/485 and released in version 4.10.0 is recording a redaction on every save, regardless of whether or not the redacted attribute has been changed.

Before:
```ruby
[4] pry(main)> model.changes_to_save
=> {}
[5] pry(main)> model.send(:audited_changes)
=> {"external_credentials"=>"[REDACTED]"}
```
After:
```ruby
[2] pry(main)> model.changes_to_save
=> {}
[3] pry(main)> model.send(:audited_changes)
=> {}
[4] pry(main)> model.external_credentials = { foo: 'bar' }
=> {:foo=>"bar"}
[5] pry(main)> model.send(:audited_changes)
=> {"external_credentials"=>["[REDACTED]", "[REDACTED]"]}
```