### PR TITLE
Revert the polymorphic indexes concurrently

### DIFF
--- a/lib/generators/audited/templates/revert_polymorphic_indexes_order.rb
+++ b/lib/generators/audited/templates/revert_polymorphic_indexes_order.rb
@@ -1,4 +1,6 @@
 class <%= migration_class_name %> < <%= migration_parent %>
+  disable_ddl_transaction!
+
   def self.up
     fix_index_order_for [:associated_id, :associated_type], 'associated_index'
     fix_index_order_for [:auditable_id, :auditable_type], 'auditable_index'
@@ -14,7 +16,7 @@ class <%= migration_class_name %> < <%= migration_parent %>
   def fix_index_order_for(columns, index_name)
     if index_exists? :audits, columns, name: index_name
       remove_index :audits, name: index_name
-      add_index :audits, columns.reverse, name: index_name
+      add_index :audits, columns.reverse, name: index_name, algorithm: :concurrently
     end
   end
 end


### PR DESCRIPTION
Index creation locks the table. This changes the migration to use [concurrent index creation](https://www.postgresql.org/docs/9.1/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY) so that there is no table lock. 

In order to use concurrent index creation, we need to disable the transaction wrapper for the index migration.