### PR TITLE
Use Thread local variables instead of Fibers

### DIFF
--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -10,7 +10,13 @@ module Audited
     end
 
     def store
-      Thread.current[:audited_store] ||= {}
+      current_store_value = Thread.current.thread_variable_get(:audited_store)
+
+      if current_store_value.nil?
+        Thread.current.thread_variable_set(:audited_store, {})
+      else
+        current_store_value
+      end
     end
 
     def config

--- a/spec/audited_spec.rb
+++ b/spec/audited_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe Audited do
+  describe "#store" do
+    describe "maintains state of store" do
+      let(:current_user) { "current_user" }
+      before { Audited.store[:current_user] = current_user }
+
+      it "when executed without fibers" do
+        expect(Audited.store[:current_user]).to eq(current_user)
+      end
+
+      it "when executed with Fibers" do
+        Fiber.new { expect(Audited.store[:current_user]).to eq(current_user) }.resume
+      end
+    end
+  end
+end


### PR DESCRIPTION
GraphQL added a [fiber-based batch loading API](https://github.com/rmosolgo/graphql-ruby/pull/3264) in one of their recent releases. 

Currently, Audited uses Fiber local state instead of Thread local state and is missing information during an audit.

I've fixed this by adding specs and changing store to Thread.