### PR TITLE
Remove the unused old_attributes method

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -80,13 +80,6 @@ module Audited
       end
     end
 
-    # Returns a hash of the changed attributes with the old values
-    def old_attributes
-      (audited_changes || {}).each_with_object({}.with_indifferent_access) do |(attr, values), attrs|
-        attrs[attr] = Array(values).first
-      end
-    end
-
     # Allows user to undo changes
     def undo
       case action

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -326,7 +326,7 @@ module Audited
 
       def comment_required_state?
         auditing_enabled &&
-        audited_changes.present? &&
+          audited_changes.present? &&
           ((audited_options[:on].include?(:create) && new_record?) ||
           (audited_options[:on].include?(:update) && persisted? && changed?))
       end

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -244,13 +244,6 @@ describe Audited::Audit do
     end
   end
 
-  describe "old_attributes" do
-    it "should return a hash of the old values" do
-      old_attributes = Audited::Audit.new(audited_changes: {a: [1, 2], b: [3, 4]}).old_attributes
-      expect(old_attributes).to eq({"a" => 1, "b" => 3})
-    end
-  end
-
   describe "as_user" do
     it "should record user objects" do
       Audited::Audit.as_user(user) do

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -946,7 +946,7 @@ describe Audited::Auditor do
       end
 
       it "should validate when audit_comment is not supplied, and only excluded attributes changed" do
-        expect(Models::ActiveRecord::CommentRequiredUser.new(password: 'Foo')).to be_valid
+        expect(Models::ActiveRecord::CommentRequiredUser.new(password: "Foo")).to be_valid
       end
     end
 
@@ -975,7 +975,7 @@ describe Audited::Auditor do
       end
 
       it "should validate when audit_comment is not supplied, and only excluded attributes changed" do
-        expect(user.update(password: 'Test')).to eq(true)
+        expect(user.update(password: "Test")).to eq(true)
       end
     end
 


### PR DESCRIPTION
While I was looking into https://github.com/collectiveidea/audited/pull/576 I noticed that the `old_attributes` method is actually unused, so I simply deleted it. I might be missing something, so feel free to close it if this was actually left in the code intentionally.