### PR TITLE
Do not test against Rails 5.0 & Ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ matrix:
     - rvm: 3.0.1
       gemfile: gemfiles/rails42.gemfile
     - rvm: 3.0.1
+      gemfile: gemfiles/rails50.gemfile
+    - rvm: 3.0.1
       gemfile: gemfiles/rails51.gemfile
     - rvm: 3.0.1
       gemfile: gemfiles/rails52.gemfile


### PR DESCRIPTION
**This is sent against the `ruby3` branch so you can more easily manage PRs, but feel free to do whatever makes sense to you as it's primarily the maintainer's choice.**

I see that https://github.com/collectiveidea/audited/pull/574 is there but the CI was failing because it was testing against Rails 5.0 and Ruby 3, which is unsupported. Other old versions are properly excluded, so it's probably the case that this was forgotten.