### PR TITLE
Resolve lingering issue from collectiveidea/audited#532

### DIFF
--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -39,9 +39,9 @@ module Audited
 end
 
 require "audited/auditor"
-require "audited/audit"
 
 ActiveSupport.on_load :active_record do
+  require "audited/audit"
   include Audited::Auditor
 end
 


### PR DESCRIPTION
While PR collectiveidea/audited#532 worked to prevent `audited` from initializing certain rails components too early, an issue remains wherein the gem entrypoint, `lib/audited.rb`, immediately requires `lib/audited/audit.rb`.

Therein, `Audited::Audit` subclasses, `ActiveRecord::Base` and thereby causes it to load too early in the Rails boot process.

This simple change merely moves the `require` of `audited/audit` into the `AR` `on_load` block.