### PR TITLE
Add audited method to parent in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ class User < ActiveRecord::Base
 end
 
 class Company < ActiveRecord::Base
+  audited
   has_many :users
   has_associated_audits
 end


### PR DESCRIPTION
When I first implemented the associated feature, I assumed the `has_associated_audits` enabled auditing of the parent model AND connected the child audits. When I tested the `company.own_and_associated_audits` I got an `undefined method 'own_and_associated_audits'`. It took me a while to guess that I needed to also added audited to the parent model. 

I think adding the `audited` call to the parent will make the docs more explicit and devs will immediately realize that `has_associated_audits` is a extra/separate call.