### PR TITLE
Support passing proc to max_audits

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -454,7 +454,9 @@ module Audited
         audited_options[:only] = Array.wrap(audited_options[:only]).map(&:to_s)
         audited_options[:except] = Array.wrap(audited_options[:except]).map(&:to_s)
         max_audits = audited_options[:max_audits] || Audited.max_audits
-        audited_options[:max_audits] = Integer(max_audits).abs if max_audits
+        return unless max_audits
+
+        audited_options[:max_audits] = max_audits.is_a?(Proc) ? Integer(max_audits.call).abs : Integer(max_audits).abs
       end
 
       def calculate_non_audited_columns


### PR DESCRIPTION
Support passing procs to `max_audits` to enable dynamic max audits.

```rb
max_audits: -> { 10 }
```

```rb
max_audits: -> { maximum_audits } 

def maximum_audits
 10
end
```