### PR TITLE
Support method symbols in max_audits

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -336,6 +336,7 @@ module Audited
 
       def combine_audits_if_needed
         max_audits = audited_options[:max_audits]
+        max_audits = Integer(method(max_audits).call).abs if max_audits.is_a?(Symbol)
         if max_audits && (extra_count = audits.count - max_audits) > 0
           audits_to_combine = audits.limit(extra_count + 1)
           combine_audits(audits_to_combine)
@@ -454,6 +455,8 @@ module Audited
         audited_options[:only] = Array.wrap(audited_options[:only]).map(&:to_s)
         audited_options[:except] = Array.wrap(audited_options[:except]).map(&:to_s)
         max_audits = audited_options[:max_audits] || Audited.max_audits
+        return if max_audits.is_a?(Symbol)
+
         audited_options[:max_audits] = Integer(max_audits).abs if max_audits
       end
 


### PR DESCRIPTION
Allow passing a method symbol to `max_audits` for dynamic maximum audits 

Example

```rb
max_audits: :max 

private 

def max
 10
end
```