### PR TITLE
Deadlocks from concurrent audit combinations

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -192,6 +192,9 @@ module Audited
         transaction do
           combine_target.save!
           audits_to_combine.unscope(:limit).where("version < ?", combine_target.version).delete_all
+	rescue ActiveRecord::Deadlocked
+	  # Ignore Deadlocks, if the same record is getting its old audits combined more than once at the same time then
+          #  both combining operations will be the same. Ignoring this error allows one of the combines to go through successfully.
         end
       end
 


### PR DESCRIPTION
When combining audits the oldest remaining audit is updated and the audits over max_audit count are deleted.
This can result in a deadlock if if the same record is updated at the same time. However by virtue of being at the same time
the same end is being selected and the same verion number is used for the delete. This means the same update and same delete
are being performed for both audit combinations so this error can just be ignored.
