### PR TITLE
Filter encrypted attributes automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,17 @@ User.auditing_enabled = false
 end
 ```
 
+### Encrypted attributes
+
+If you're using ActiveRecord's encryption (available from Rails 7) to encrypt some attributes, Audited will automatically filter values of these attributes. No additional configuration is required. Changes to encrypted attributes will be logged as `[FILTERED]`.
+
+```ruby
+class User < ActiveRecord::Base
+  audited
+  encrypts :password
+end
+```
+
 ### Custom `Audit` model
 
 If you want to extend or modify the audit model, create a new class that

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -234,6 +234,14 @@ describe Audited::Auditor do
       expect(user.audits.last.audited_changes["password"]).to eq(["My", "Custom", "Value", 7])
     end
 
+    if ::ActiveRecord::VERSION::MAJOR >= 7
+      it "should filter encrypted attributes" do
+        user = Models::ActiveRecord::UserWithEncryptedPassword.create(password: "password")
+        user.save
+        expect(user.audits.last.audited_changes["password"]).to eq("[FILTERED]")
+      end
+    end
+
     if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
       describe "'json' and 'jsonb' audited_changes column type" do
         let(:migrations_path) { SPEC_ROOT.join("support/active_record/postgres") }

--- a/spec/rails_app/config/environments/test.rb
+++ b/spec/rails_app/config/environments/test.rb
@@ -44,4 +44,9 @@ RailsApp::Application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  if ::ActiveRecord::VERSION::MAJOR >= 7
+    config.active_record.encryption.key_derivation_salt = SecureRandom.hex
+    config.active_record.encryption.primary_key = SecureRandom.hex
+  end
 end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -41,6 +41,14 @@ module Models
       audited redacted: :password, redaction_value: ["My", "Custom", "Value", 7]
     end
 
+    if ::ActiveRecord::VERSION::MAJOR >= 7
+      class UserWithEncryptedPassword < ::ActiveRecord::Base
+        self.table_name = :users
+        audited
+        encrypts :password
+      end
+    end
+
     class CommentRequiredUser < ::ActiveRecord::Base
       self.table_name = :users
       audited except: :password, comment_required: true


### PR DESCRIPTION
Rails 7 introduces built-in attributes encryption: https://edgeguides.rubyonrails.org/active_record_encryption.html
Those are configured with `encrypts` keyword, eg: `encrypts :password`

Because these attributes are considered sensitive, we shouldn't write plain unencrypted values to our audits table by default.