### PR TITLE
Ensure audits are re-enabled after blocks

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -396,7 +396,7 @@ module Audited
       #   end
       #
       def without_auditing
-        auditing_was_enabled = auditing_enabled
+        auditing_was_enabled = class_auditing_enabled
         disable_auditing
         yield
       ensure
@@ -410,7 +410,7 @@ module Audited
       #   end
       #
       def with_auditing
-        auditing_was_enabled = auditing_enabled
+        auditing_was_enabled = class_auditing_enabled
         enable_auditing
         yield
       ensure
@@ -434,7 +434,7 @@ module Audited
       end
 
       def auditing_enabled
-        Audited.store.fetch("#{table_name}_auditing_enabled", true) && Audited.auditing_enabled
+        class_auditing_enabled && Audited.auditing_enabled
       end
 
       def auditing_enabled=(val)
@@ -464,6 +464,10 @@ module Audited
         else
           default_ignored_attributes
         end
+      end
+
+      def class_auditing_enabled
+        Audited.store.fetch("#{table_name}_auditing_enabled", true)
       end
     end
   end

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -814,6 +814,15 @@ describe Audited::Auditor do
       }.to_not change(Audited::Audit, :count)
     end
 
+    context "when global audits are disabled" do
+      it "should re-enable class audits after #without_auditing block" do
+        Audited.auditing_enabled = false
+        Models::ActiveRecord::User.without_auditing {}
+        Audited.auditing_enabled = true
+        expect(Models::ActiveRecord::User.auditing_enabled).to eql(true)
+      end
+    end
+
     it "should reset auditing status even it raises an exception" do
       begin
         Models::ActiveRecord::User.without_auditing { raise }
@@ -882,6 +891,15 @@ describe Audited::Auditor do
         Models::ActiveRecord::User.with_auditing { Models::ActiveRecord::User.create!(name: "Brandon") }
         Models::ActiveRecord::User.auditing_enabled = true
       }.to change(Audited::Audit, :count).by(1)
+    end
+
+    context "when global audits are disabled" do
+      it "should re-enable class audits after #with_auditing block" do
+        Audited.auditing_enabled = false
+        Models::ActiveRecord::User.with_auditing {}
+        Audited.auditing_enabled = true
+        expect(Models::ActiveRecord::User.auditing_enabled).to eql(true)
+      end
     end
 
     it "should reset auditing status even it raises an exception" do


### PR DESCRIPTION
Ensures that auditing is re-enabled after `with_auditing` and `without_auditing` blocks.

Previously, if audits were disabled globally using `Audited.auditing_enabled = false` followed by use of a `with_auditing` or `without_auditing` block, then the class-level auditing is left disabled for the model on which `with_auditing` or `without_auditing` was called.

Resolves https://github.com/collectiveidea/audited/issues/534