### PR TITLE
Updated readme, should set custom class after_load active_record

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,9 +400,10 @@ end
 Then set it in an initializer:
 ```ruby
 # config/initializers/audited.rb
-
-Audited.config do |config|
-  config.audit_class = CustomAudit
+ActiveSupport.on_load :active_record do
+  Audited.config do |config|
+    config.audit_class = CustomAudit
+  end
 end
 ```
 


### PR DESCRIPTION
To avoid errors, you need to load the settings after active_record

Otherwise there will be errors
```
/Users/stonegod/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/activerecord-7.0.3.1/lib/active_record/autosave_association.rb:424:in `block in save_collection_association': Validation failed: Audits is invalid (ActiveRecord::RecordInvalid)
```

```
/Users/stonegod/kvantera/megafon-multifon-admin-backend/app/models/custom_audit.rb:1:in `<top (required)>': uninitialized constant Audited::Audit (NameError)

class CustomAudit < Audited::Audit
                           ^^^^^^^
Did you mean?  Audited::Auditor
```