### PR TITLE
Fix typo: PostgresSQL -> PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           - ruby: 2.3
             db: MYSQL
 
-          # PostgresSQL is segfaulting on 2.3
+          # PostgreSQL is segfaulting on 2.3
           # Doesn't seem worth solving.
           - ruby: 2.3
             db: POSTGRES


### PR DESCRIPTION
See their own spelling on:
https://www.postgresql.org/about/