### PR TITLE
Add testing and document support for Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2]
         appraisal:
           - rails50
           - rails51
@@ -43,6 +43,8 @@ jobs:
             ruby: 3.0
           - appraisal: rails50
             ruby: 3.1
+          - appraisal: rails50
+            ruby: 3.2
 
           # Rails 5.1 supports Ruby 2.2-2.5
           - appraisal: rails51
@@ -53,6 +55,8 @@ jobs:
             ruby: 3.0
           - appraisal: rails51
             ruby: 3.1
+          - appraisal: rails51
+            ruby: 3.2
 
           # Rails 5.2 supports Ruby 2.2-2.5
           - appraisal: rails52
@@ -63,6 +67,8 @@ jobs:
             ruby: 3.0
           - appraisal: rails52
             ruby: 3.1
+          - appraisal: rails52
+            ruby: 3.2
 
           # Rails 6.0 supports Ruby 2.5-2.7
           - appraisal: rails60
@@ -73,6 +79,8 @@ jobs:
             ruby: 3.0
           - appraisal: rails60
             ruby: 3.1
+          - appraisal: rails60
+            ruby: 3.2
 
           # Rails 6.1 supports Ruby 2.5+
           - appraisal: rails61

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Audited supports and is [tested against](https://github.com/collectiveidea/audit
 * 2.7
 * 3.0
 * 3.1
+* 3.2
 
 Audited may work just fine with a Ruby version not listed above, but we can't guarantee that it will. If you'd like to maintain a Ruby that isn't listed, please let us know with a [pull request](https://github.com/collectiveidea/audited/pulls).
 


### PR DESCRIPTION
Released 25 Dec 2022:
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/