### PR TITLE
Run GitHub actions on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: CI
 
 on:
-  pull_request:
-  push:
-    branches:
-    - main
+  - pull_request
+  - push
 
 jobs:
   build:


### PR DESCRIPTION
To all for an improved contributing experience, run GitHub actions on all branches.

When preparing a PR, I like to verify that all CI will be green on my personal fork. However, the existing GitHub actions configuration made it so this would not happen.

Now, contributors can run actions on their fork before opening a PR.