### PR TITLE
Replace Rails version check with ActiveRecord version check 

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -174,7 +174,7 @@ module Audited
       if action == "create"
         self.version = 1
       else
-        collection = (Rails::VERSION::MAJOR >= 6) ? self.class.unscoped : self.class
+        collection = (ActiveRecord::VERSION::MAJOR >= 6) ? self.class.unscoped : self.class
         max = collection.auditable_finder(auditable_id, auditable_type).maximum(:version) || 0
         self.version = max + 1
       end


### PR DESCRIPTION
so that audited gem can be used with non Rails projects, such as we do with Padrino

implements suggestions from https://github.com/collectiveidea/audited/issues/561