### PR TITLE
Audit touch calls

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -234,8 +234,10 @@ module Audited
       def audited_changes(for_touch: false)
         all_changes = if for_touch
                         previous_changes
+                      elsif respond_to?(:changes_to_save)
+                        changes_to_save
                       else
-                        respond_to?(:changes_to_save) ? changes_to_save : changes
+                        changes
                       end
 
         filtered_changes = \

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -487,7 +487,7 @@ module Audited
 
       def normalize_audited_options
         audited_options[:on] = Array.wrap(audited_options[:on])
-        audited_options[:on] = [:create, :update, :destroy] if audited_options[:on].empty?
+        audited_options[:on] = [:create, :update, :touch, :destroy] if audited_options[:on].empty?
         audited_options[:only] = Array.wrap(audited_options[:only]).map(&:to_s)
         audited_options[:except] = Array.wrap(audited_options[:except]).map(&:to_s)
         max_audits = audited_options[:max_audits] || Audited.max_audits

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -84,7 +84,7 @@ module Audited
 
         after_create :audit_create if audited_options[:on].include?(:create)
         before_update :audit_update if audited_options[:on].include?(:update)
-        after_touch :audit_touch if audited_options[:on].include?(:touch)
+        after_touch :audit_touch if audited_options[:on].include?(:touch) && ::ActiveRecord::VERSION::MAJOR >= 6
         before_destroy :audit_destroy if audited_options[:on].include?(:destroy)
 
         # Define and set after_audit and around_audit callbacks. This might be useful if you want

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -414,37 +414,39 @@ describe Audited::Auditor do
     end
   end
 
-  describe "on touch" do
-    before do
-      @user = create_user(name: "Brandon", status: :active, audit_comment: "Touch")
-    end
+  if ::ActiveRecord::VERSION::MAJOR >= 6
+    describe "on touch" do
+      before do
+        @user = create_user(name: "Brandon", status: :active, audit_comment: "Touch")
+      end
 
-    it "should save an audit" do
-      expect { @user.touch(:suspended_at) }.to change(Audited::Audit, :count).by(1)
-    end
+      it "should save an audit" do
+        expect { @user.touch(:suspended_at) }.to change(Audited::Audit, :count).by(1)
+      end
 
-    it "should set the action to 'update'" do
-      @user.touch(:suspended_at)
-      expect(@user.audits.last.action).to eq("update")
-      expect(Audited::Audit.updates.order(:id).last).to eq(@user.audits.last)
-      expect(@user.audits.updates.last).to eq(@user.audits.last)
-    end
+      it "should set the action to 'update'" do
+        @user.touch(:suspended_at)
+        expect(@user.audits.last.action).to eq("update")
+        expect(Audited::Audit.updates.order(:id).last).to eq(@user.audits.last)
+        expect(@user.audits.updates.last).to eq(@user.audits.last)
+      end
 
-    it "should store the changed attributes" do
-      @user.touch(:suspended_at)
-      expect(@user.audits.last.audited_changes["suspended_at"][0]).to be_nil
-      expect(@user.audits.last.audited_changes["suspended_at"][1]).to be_within(1).of(Time.current)
-    end
+      it "should store the changed attributes" do
+        @user.touch(:suspended_at)
+        expect(@user.audits.last.audited_changes["suspended_at"][0]).to be_nil
+        expect(@user.audits.last.audited_changes["suspended_at"][1]).to be_within(1).of(Time.current)
+      end
 
-    it "should store audit comment" do
-      expect(@user.audits.last.comment).to eq("Touch")
-    end
+      it "should store audit comment" do
+        expect(@user.audits.last.comment).to eq("Touch")
+      end
 
-    it "should not save an audit if only specified on create/destroy" do
-      on_create_destroy = Models::ActiveRecord::OnCreateDestroyUser.create(name: "Bart")
-      expect {
-        on_create_destroy.touch(:suspended_at)
-      }.to_not change(Audited::Audit, :count)
+      it "should not save an audit if only specified on create/destroy" do
+        on_create_destroy = Models::ActiveRecord::OnCreateDestroyUser.create(name: "Bart")
+        expect {
+          on_create_destroy.touch(:suspended_at)
+        }.to_not change(Audited::Audit, :count)
+      end
     end
   end
 

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -434,7 +434,7 @@ describe Audited::Auditor do
       it "should store the changed attributes" do
         @user.touch(:suspended_at)
         expect(@user.audits.last.audited_changes["suspended_at"][0]).to be_nil
-        expect(@user.audits.last.audited_changes["suspended_at"][1]).to be_within(1.second).of(Time.current)
+        expect(Time.parse(@user.audits.last.audited_changes["suspended_at"][1].to_s)).to be_within(1.second).of(Time.current)
       end
 
       it "should store audit comment" do

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -414,6 +414,45 @@ describe Audited::Auditor do
     end
   end
 
+  describe "on touch" do
+    before do
+      @user = create_user(name: "Brandon", status: :active, audit_comment: "Touch")
+    end
+
+    around do |example|
+      freeze_time do
+        example.run
+      end
+    end
+
+    it "should save an audit" do
+      expect { @user.touch(:suspended_at) }.to change(Audited::Audit, :count).by(1)
+    end
+
+    it "should set the action to 'update'" do
+      @user.touch(:suspended_at)
+      expect(@user.audits.last.action).to eq("update")
+      expect(Audited::Audit.updates.order(:id).last).to eq(@user.audits.last)
+      expect(@user.audits.updates.last).to eq(@user.audits.last)
+    end
+
+    it "should store the changed attributes" do
+      @user.touch(:suspended_at)
+      expect(@user.audits.last.audited_changes).to eq({"suspended_at" => [nil, Time.current]})
+    end
+
+    it "should store audit comment" do
+      expect(@user.audits.last.comment).to eq("Touch")
+    end
+
+    it "should not save an audit if only specified on create/destroy" do
+      on_create_destroy = Models::ActiveRecord::OnCreateDestroyUser.create(name: "Bart")
+      expect {
+        on_create_destroy.touch(:suspended_at)
+      }.to_not change(Audited::Audit, :count)
+    end
+  end
+
   describe "on destroy" do
     before do
       @user = create_user(status: :active)

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
-SingleCov.covered! uncovered: 9 # not testing proxy_respond_to? hack / 2 methods / deprecation of `version`
+# not testing proxy_respond_to? hack / 2 methods / deprecation of `version`
+# also, an additional 3 around `after_touch` for Versions before 6.
+uncovered = ActiveRecord::VERSION::MAJOR < 6 ? 12 : 9
+SingleCov.covered! uncovered: uncovered
 
 class ConditionalPrivateCompany < ::ActiveRecord::Base
   self.table_name = "companies"

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -419,12 +419,6 @@ describe Audited::Auditor do
       @user = create_user(name: "Brandon", status: :active, audit_comment: "Touch")
     end
 
-    around do |example|
-      freeze_time do
-        example.run
-      end
-    end
-
     it "should save an audit" do
       expect { @user.touch(:suspended_at) }.to change(Audited::Audit, :count).by(1)
     end
@@ -438,7 +432,8 @@ describe Audited::Auditor do
 
     it "should store the changed attributes" do
       @user.touch(:suspended_at)
-      expect(@user.audits.last.audited_changes).to eq({"suspended_at" => [nil, Time.current]})
+      expect(@user.audits.last.audited_changes["suspended_at"][0]).to be_nil
+      expect(@user.audits.last.audited_changes["suspended_at"][1]).to be_within(1).of(Time.current)
     end
 
     it "should store audit comment" do

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -434,7 +434,7 @@ describe Audited::Auditor do
       it "should store the changed attributes" do
         @user.touch(:suspended_at)
         expect(@user.audits.last.audited_changes["suspended_at"][0]).to be_nil
-        expect(@user.audits.last.audited_changes["suspended_at"][1]).to be_within(1).of(Time.current)
+        expect(@user.audits.last.audited_changes["suspended_at"][1]).to be_within(1.second).of(Time.current)
       end
 
       it "should store audit comment" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,6 @@ Dir[SPEC_ROOT.join("support/*.rb")].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.include AuditedSpecHelpers
-  config.include ActiveSupport::Testing::TimeHelpers
   config.use_transactional_fixtures = false if Rails.version.start_with?("4.")
   config.use_transactional_tests = false if config.respond_to?(:use_transactional_tests=)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ Dir[SPEC_ROOT.join("support/*.rb")].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.include AuditedSpecHelpers
+  config.include ActiveSupport::Testing::TimeHelpers
   config.use_transactional_fixtures = false if Rails.version.start_with?("4.")
   config.use_transactional_tests = false if config.respond_to?(:use_transactional_tests=)
 end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -146,6 +146,11 @@ module Models
       audited on: [:create, :destroy]
     end
 
+    class OnCreateDestroyUser < ::ActiveRecord::Base
+      self.table_name = "users"
+      audited on: [:create, :destroy]
+    end
+
     class OnCreateDestroyExceptName < ::ActiveRecord::Base
       self.table_name = "companies"
       audited except: :name, on: [:create, :destroy]


### PR DESCRIPTION
Touch is a form of `update` which generally doesn't call callbacks.  It does, however, invoke an `after_touch` callback that can be leveraged to store away audit information.  This can be informative with fields such as `locked_at` housing a timestamp for when a user account is locked and `nil` when the user's account is unlocked.  Having historical information about when a user was locked/unlocked and auditing comments around the why, is handy.