### PR TITLE
For touch audit don't save if it exactly matches update audit

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -333,10 +333,16 @@ module Audited
       end
 
       def audit_touch
-        unless (changes = audited_changes(for_touch: true)).empty?
-          write_audit(action: "update", audited_changes: changes,
-            comment: audit_comment)
-        end
+        changes = audited_changes(for_touch: true)
+
+        return if changes.empty?
+
+        audit_attrs = { action: "update", audited_changes: changes, comment: audit_comment }
+
+        # Ensure we're not attempting to audit the same as a just audited update:
+        return if audits.where(audit_attrs).last == audits.last
+
+        write_audit(audit_attrs)
       end
 
       def audit_destroy


### PR DESCRIPTION
I noticed with auditing on touches, sometimes (possibly only w/ ActiveStorage associations), there appears to be a double audit due to touch.

If you have a model w/
```ruby
class User < ApplicationRecord
  audited
  has_one_attached :file
end
```
and you want to change the user's name, as well as upload the attached file, via something like:
```ruby
u = User.first
file = File.open("/some/path/to/a/file.jpg")
u.name = "My User"
u.file.attach(io: file, filename: "file.jpg")
u.save!
```
there ends up being 2 audits created, one from the default update action, and a second from the touch via ActiveStorage on attachment which will both have the:
```ruby
:audited_changes => {
  "name" => [
    nil,
    "My User"
  ]
}
```

With this change, when auditing a touch event, we'll look to the last update audit and see if it's the same as what we'll now be auditing as a touch.  If these do match, there's no sense in duplicating so we'll simply skip the touch audit.