### PR TITLE
Don't double audit on touch for create / update actions

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -247,6 +247,13 @@ module Audited
             all_changes.except(*self.class.non_audited_columns)
           end
 
+        if for_touch
+          filtered_changes.reject! do |k, v|
+            audits.last.audited_changes[k].to_json == v.to_json ||
+            audits.last.audited_changes[k].to_json == v[1].to_json
+          end
+        end
+
         filtered_changes = redact_values(filtered_changes)
         filtered_changes = filter_encrypted_attrs(filtered_changes)
         filtered_changes = normalize_enum_changes(filtered_changes)

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -124,11 +124,12 @@ module Models
       audited
       has_associated_audits
       has_many :companies, class_name: "OwnedCompany", dependent: :destroy
+      accepts_nested_attributes_for :companies
     end
 
     class OwnedCompany < ::ActiveRecord::Base
       self.table_name = "companies"
-      belongs_to :owner, class_name: "Owner"
+      belongs_to :owner, class_name: "Owner", touch: true
       attr_accessible :name, :owner if respond_to?(:attr_accessible) # declare attr_accessible before calling aaa
       audited associated_with: :owner
     end


### PR DESCRIPTION
When introducing the touch audit, we overlooked touch on association (`belongs_to :model, touch: true`) and this PR resolves that.  This comes up when a model has an association setup w/ a touch, which could possibly be behind the scenes like when it comes to ActiveStorage objects.

E.g. W/ a basic model setup
```ruby
module Company < ApplicationRecord
  has_many :employees
end

module Employee < ApplicationRecord
  belongs_to :company, touch: true
end
```
If a company is created w/ an employee included...
```ruby
company = Company.create!(name: "Company A", employees_attributes: [{ name: "Employee 1", hired_at: Time.zone.current }])
```
Before this update we would end up with a "create" and an "update" audit for the company where the "update" audit is essentially the same data as the "create" audit.  This PR essentially scrubs out the attributes if they match the prior audit during a touch audit.