### PR TITLE
Touch Audit - Ensure previous auditing

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -249,6 +249,8 @@ module Audited
 
         if for_touch
           filtered_changes.reject! do |k, v|
+            next unless audits.present?
+
             audits.last.audited_changes[k].to_json == v.to_json ||
             audits.last.audited_changes[k].to_json == v[1].to_json
           end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -161,5 +161,10 @@ module Models
       self.table_name = "companies"
       audited on: [:create, :update]
     end
+
+    class OnTouchOnly < ::ActiveRecord::Base
+      self.table_name = "users"
+      audited on: [:touch]
+    end
   end
 end


### PR DESCRIPTION
If records are looking to audit for touch, but have yet to be audited, or are specifically auditing _just_ touch events, ensure we're not failing due to a bad previous audit check.