### PR TITLE
Reflect Rails' serializer changes

### DIFF
--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -10,7 +10,10 @@ module Audited
       :ignored_attributes,
       :max_audits,
       :store_synthesized_enums
-    attr_writer :audit_class
+    attr_writer \
+      :audit_class,
+      :encoding_type
+
 
     def audit_class
       # The audit_class is set as String in the initializer. It can not be constantized during initialization and must
@@ -22,6 +25,20 @@ module Audited
     # remove audit_model in next major version it was only shortly present in 5.1.0
     alias_method :audit_model, :audit_class
     deprecate audit_model: "use Audited.audit_class instead of Audited.audit_model. This method will be removed."
+
+    def encoding_type
+      @encoding_type ||= :json
+    end
+
+    def coder
+      if encoding_type == :json
+        ActiveRecord::Coders::JSON
+      elsif encoding_type == :yaml
+        ActiveRecord::Coders::YAMLColumn
+      else
+        ActiveRecord::Coders::ColumnSerializer
+      end
+    end
 
     def store
       current_store_value = Thread.current.thread_variable_get(:audited_store)

--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -15,30 +15,6 @@ module Audited
   # * <tt>created_at</tt>: Time that the change was performed
   #
 
-  class YAMLIfTextColumnType
-    class << self
-      def load(obj)
-        if text_column?
-          ActiveRecord::Coders::YAMLColumn.new(Object).load(obj)
-        else
-          obj
-        end
-      end
-
-      def dump(obj)
-        if text_column?
-          ActiveRecord::Coders::YAMLColumn.new(Object).dump(obj)
-        else
-          obj
-        end
-      end
-
-      def text_column?
-        Audited.audit_class.columns_hash["audited_changes"].type.to_s == "text"
-      end
-    end
-  end
-
   class Audit < ::ActiveRecord::Base
     belongs_to :auditable, polymorphic: true
     belongs_to :user, polymorphic: true
@@ -49,7 +25,7 @@ module Audited
     cattr_accessor :audited_class_names
     self.audited_class_names = Set.new
 
-    serialize :audited_changes, YAMLIfTextColumnType
+    serialize :audited_changes, coder: Audited.coder
 
     scope :ascending, -> { reorder(version: :asc) }
     scope :descending, -> { reorder(version: :desc) }

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -69,11 +69,6 @@ describe Audited::Audit do
       expect(audit.audited_changes).to eq foo: "bar"
     end
 
-    it "does not unserialize from binary columns" do
-      allow(Audited::YAMLIfTextColumnType).to receive(:text_column?).and_return(false)
-      audit.audited_changes = {foo: "bar"}
-      expect(audit.audited_changes).to eq "{:foo=>\"bar\"}"
-    end
   end
 
   describe "#undo" do


### PR DESCRIPTION
As a result of [Rails PR#47463](https://github.com/rails/rails/pull/47463), serialization is now type-checked, and so the approach of dynamically deciding when calling `#load` and `#dump` no longer works.

This means that you'll get the following errors/deprecation warnings when using Edge Rails with Audited:

```
DEPRECATION WARNING:                 Passing the class as positional argument is deprecated and will be remove in Rails 7.2.

                Please pass the class as a keyword argument:

                  serialize :audited_changes, type: Audited::YAMLIfTextColumnType
 (called from <class:Audit> at /Users/nik/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/audited-5.3.2/lib/audited/audit.rb:52)
```

And:

```
ActiveRecord::SerializationTypeMismatch: can't serialize `audited_changes`: was supposed to be a Audited::YAMLIfTextColumnType, but was a Hash. -- { ... }
```

(The first is just a syntax thing to be fair)

I don't know the best way to fix it to be honest - determining the column type would require connecting to the database on load, so that's sub-optimal. It might be possible to implement a `Coder` class that dynamically switches and passes the type checking?

This is the commit I'm using, which adds a configuration setting to choose json encoding by default (replaces the existing approach). This seems like something worth considering as it seems Rails has moved away from YAML for good reasons too. 

I've sent the PR in case it's useful, but of course it's a breaking change and I think there might be a better approach - figured I'd start the discussion anyway 😄 

Thank you! 