### PR TITLE
Conditional require railtie to support using audited gem in non-Rails projects

### DIFF
--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -53,4 +53,4 @@ ActiveSupport.on_load :active_record do
 end
 
 require "audited/sweeper"
-require "audited/railtie"
+require "audited/railtie" if Audited.const_defined?(:Rails)


### PR DESCRIPTION
A follow-up change to https://github.com/collectiveidea/audited/pull/655. This is required to make audited gem usable by non-Rails projects.