### PR TITLE
Ignore callbacks if not specifed on the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,14 +133,14 @@ end
 
 ### Specifying callbacks
 
-By default, a new audit is created for any Create, Update or Destroy action. You can, however, limit the actions audited.
+By default, a new audit is created for any Create, Update, Touch (Rails 6+) or Destroy action. You can, however, limit the actions audited.
 
 ```ruby
 class User < ActiveRecord::Base
   # All fields and actions
   # audited
 
-  # Single field, only audit Update and Destroy (not Create)
+  # Single field, only audit Update and Destroy (not Create or Touch)
   # audited only: :name, on: [:update, :destroy]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ end
 You can ignore the default callbacks globally unless the callback action is specified in your model using the `:on` option. To configure default callback exclusion, put the following in an initializer file (`config/initializers/audited.rb`):
 
 ```ruby
-Audited.ignored_default_callbacks = [:create, :update] # ignore callbacks create and delete
+Audited.ignored_default_callbacks = [:create, :update] # ignore callbacks create and update
 ```
 
 ### Comments

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ class User < ActiveRecord::Base
 end
 ```
 
+You can ignore the default callbacks globally unless the callback action is specified in your model using the `:on` option. To configure default callback exclusion, put the following in an initializer file (`config/initializers/audited.rb`):
+
+```ruby
+Audited.ignored_default_callbacks = [:create, :update] # ignore callbacks create and delete
+```
+
 ### Comments
 
 You can attach comments to each audit using an `audit_comment` attribute on your model.

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -9,6 +9,7 @@ module Audited
       :auditing_enabled,
       :current_user_method,
       :ignored_attributes,
+      :ignored_default_callbacks,
       :max_audits,
       :store_synthesized_enums
     attr_writer :audit_class
@@ -34,6 +35,7 @@ module Audited
   end
 
   @ignored_attributes = %w[lock_version created_at updated_at created_on updated_on]
+  @ignored_default_callbacks = []
 
   @current_user_method = :current_user
   @auditing_enabled = true

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -496,7 +496,7 @@ module Audited
 
       def normalize_audited_options
         audited_options[:on] = Array.wrap(audited_options[:on])
-        audited_options[:on] = [:create, :update, :touch, :destroy] if audited_options[:on].empty?
+        audited_options[:on] = ([:create, :update, :touch, :destroy] - Audited.ignored_default_callbacks) if audited_options[:on].empty?
         audited_options[:only] = Array.wrap(audited_options[:only]).map(&:to_s)
         audited_options[:except] = Array.wrap(audited_options[:except]).map(&:to_s)
         max_audits = audited_options[:max_audits] || Audited.max_audits

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -245,6 +245,27 @@ describe Audited::Auditor do
       expect(user.audits.last.audited_changes["password"]).to eq(["My", "Custom", "Value", 7])
     end
 
+    context "when ignored_default_callbacks is set" do
+      before { Audited.ignored_default_callbacks = [:create] }
+      after { Audited.ignored_default_callbacks = [] }
+
+      it "should remove create callback" do
+        class DefaultCallback < ::ActiveRecord::Base
+          audited
+        end
+
+        expect(DefaultCallback.audited_options[:on]).to eq([:update, :touch, :destroy])
+      end
+
+      it "should keep create callback if specified" do
+        class CallbacksSpecified < ::ActiveRecord::Base
+          audited on: [:create, :update, :destroy]
+        end
+
+        expect(CallbacksSpecified.audited_options[:on]).to eq([:create, :update, :destroy])
+      end
+    end
+
     if ::ActiveRecord::VERSION::MAJOR >= 7
       it "should filter encrypted attributes" do
         user = Models::ActiveRecord::UserWithEncryptedPassword.create(password: "password")


### PR DESCRIPTION
Related comment/discussion: https://github.com/collectiveidea/audited/pull/662#issuecomment-1637265004

With the addition of [touch auditing](https://github.com/collectiveidea/audited/pull/657), I thought maybe a configuration  could exclude certain callbacks unless the callback action was specified on the model.

```Ruby
Audited.ignored_default_callbacks = [:touch]

class User < ActiveRecord::Base
   audited
end
# audits on action :create, :update, :destroy

class Company < ActiveRecord::Base
  audited on: [:create, :touch]
end
# audits on action :create, :touch
```