### PR TITLE
Provide a way to rebuild data with missing create audit

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -415,6 +415,11 @@ module Audited
 
       def reconstruct_attributes(audits)
         attributes = {}
+
+        unless self.audits.creates.any?
+          self.audits.each { |audit| attributes.merge!(audit.old_attributes) }
+        end
+
         audits.each { |audit| attributes.merge!(audit.new_attributes) }
         attributes
       end


### PR DESCRIPTION
After discovering issue https://github.com/collectiveidea/audited/issues/680, this provides a starting point to discuss rebuilding data for attributes when there's a missing create audit.