### PR TITLE
Robustify Rails version checks

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -49,7 +49,7 @@ module Audited
     cattr_accessor :audited_class_names
     self.audited_class_names = Set.new
 
-    if Rails.version >= "7.1"
+    if Rails.gem_version >= Gem::Version.new("7.1")
       serialize :audited_changes, coder: YAMLIfTextColumnType
     else
       serialize :audited_changes, YAMLIfTextColumnType

--- a/lib/generators/audited/migration.rb
+++ b/lib/generators/audited/migration.rb
@@ -16,7 +16,7 @@ module Audited
       private
 
       def timestamped_migrations?
-        (Rails.version >= "7.0") ?
+        (Rails.gem_version >= Gem::Version.new("7.0")) ?
           ::ActiveRecord.timestamped_migrations :
           ::ActiveRecord::Base.timestamped_migrations
       end

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -30,7 +30,7 @@ module RailsApp
           ActiveSupport::TimeWithZone ActiveSupport::TimeZone ActiveSupport::HashWithIndifferentAccess]
     end
 
-    if Rails.version >= "7.1"
+    if Rails.gem_version >= Gem::Version.new("7.1")
       config.active_support.cache_format_version = 7.1
     end
   end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -5,11 +5,11 @@ module Models
   module ActiveRecord
     class User < ::ActiveRecord::Base
       audited except: :password
-      attribute :non_column_attr if Rails.version >= "5.1"
+      attribute :non_column_attr if Rails.gem_version >= Gem::Version.new("5.1")
       attr_protected :logins if respond_to?(:attr_protected)
       enum status: {active: 0, reliable: 1, banned: 2}
 
-      if Rails.version >= "7.1"
+      if Rails.gem_version >= Gem::Version.new("7.1")
         serialize :phone_numbers, type: Array
       else
         serialize :phone_numbers, Array
@@ -27,7 +27,7 @@ module Models
 
     class UserOnlyPassword < ::ActiveRecord::Base
       self.table_name = :users
-      attribute :non_column_attr if Rails.version >= "5.1"
+      attribute :non_column_attr if Rails.gem_version >= Gem::Version.new("5.1")
       audited only: :password
     end
 


### PR DESCRIPTION
Ensure Rails versions are properly checked, instead of relying on `String` comparisons.

Example of why this is an issue
```ruby
[8] pry(main)> Rails.version > "10.2.3"
=> true
[9] pry(main)> Gem::Version.new(Rails.version) >= Gem::Version.new("10.2.3")
=> false
```
This example was taken from [this comment](https://github.com/collectiveidea/audited/pull/686#discussion_r1353239732) on a recent PR.

## Approach

This change leverages the already existing function `Rails.gem_version`. This has been part of the Rails codebase for 10+ years, making it compatible with all supported Rails versions.