### PR TITLE
 New configurable settings: encryption for audited_changes & filtering encrypted attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,17 @@ class User < ActiveRecord::Base
 end
 ```
 
+You can disable the filtering by adding a config
+
+```ruby
+Audited.filter_encrypted_attributes = false
+```
+
+If you want to encrypt the changes that are audited, you can simply add this line to your config
+```ruby
+Audited.encrypt_audited_changes = true
+```
+
 ### Custom `Audit` model
 
 If you want to extend or modify the audit model, create a new class that

--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -8,6 +8,8 @@ module Audited
     attr_accessor \
       :auditing_enabled,
       :current_user_method,
+      :encrypt_audited_changes,
+      :filter_encrypted_attributes,
       :ignored_attributes,
       :ignored_default_callbacks,
       :max_audits,
@@ -40,6 +42,8 @@ module Audited
 
   @current_user_method = :current_user
   @auditing_enabled = true
+  @encrypt_audited_changes = false
+  @filter_encrypted_attributes = true
   @store_synthesized_enums = false
 end
 

--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -55,6 +55,10 @@ module Audited
       serialize :audited_changes, YAMLIfTextColumnType
     end
 
+    if Rails.gem_version >= Gem::Version.new("7.0") && Audited.encrypt_audited_changes
+      encrypts :audited_changes
+    end
+
     scope :ascending, -> { reorder(version: :asc) }
     scope :descending, -> { reorder(version: :desc) }
     scope :creates, -> { where(action: "create") }

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -289,6 +289,8 @@ module Audited
       end
 
       def filter_encrypted_attrs(filtered_changes)
+        return filtered_changes unless filter_encrypted_attributes?
+
         filter_attr_values(
           audited_changes: filtered_changes,
           attrs: respond_to?(:encrypted_attributes) ? Array(encrypted_attributes).map(&:to_s) : []
@@ -419,6 +421,10 @@ module Audited
         attributes = {}
         audits.each { |audit| attributes.merge!(audit.new_attributes) }
         attributes
+      end
+
+      def filter_encrypted_attributes?
+        Audited.filter_encrypted_attributes
       end
     end
 

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -74,6 +74,24 @@ describe Audited::Audit do
       audit.audited_changes = {foo: "bar"}
       expect(audit.audited_changes).to eq "{:foo=>\"bar\"}"
     end
+
+    if ::ActiveRecord::VERSION::MAJOR >= 7
+      context "when encryption is enabled" do
+        before do
+          Audited.encrypt_audited_changes = true
+        end
+
+        it "encrypts the whole column" do
+          company = Models::ActiveRecord::EncryptCompanyAuditedChanges.create!(name: "CollectiveIdea")
+
+          audit = company.audits.last
+          audited_changes = audit.audited_changes
+
+          expect({"name"=>"CollectiveIdea", "owner_id"=>nil}).not_to eq(audit.ciphertext_for(:audited_changes))
+          expect({"name"=>"CollectiveIdea", "owner_id"=>nil}).to eq(audited_changes)
+        end
+      end
+    end
   end
 
   describe "#undo" do

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -267,10 +267,22 @@ describe Audited::Auditor do
     end
 
     if ::ActiveRecord::VERSION::MAJOR >= 7
-      it "should filter encrypted attributes" do
+      it "should filter encrypted attributes by default" do
         user = Models::ActiveRecord::UserWithEncryptedPassword.create(password: "password")
         user.save
         expect(user.audits.last.audited_changes["password"]).to eq("[FILTERED]")
+      end
+
+      context "when filtering is disabled" do
+        before do
+          Audited.filter_encrypted_attributes = false
+        end
+
+        it "should not filter encrypted attributes" do
+          user = Models::ActiveRecord::UserWithEncryptedPassword.create(password: "password")
+          user.save
+          expect(user.audits.last.audited_changes["password"]).not_to eq("[FILTERED]")
+        end
       end
     end
 

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -127,6 +127,9 @@ module Models
       audited
     end
 
+    class EncryptCompanyAuditedChanges < Company
+    end
+
     class Company::STICompany < Company
     end
 


### PR DESCRIPTION
Closes #690

* Add new configurable vars:
  * `encrypt_audited_changes` default to `false`
  * `filter_encrypted_attributes` default to `true`