### PR TITLE
fix: normalize enum changes before filtering duplicate audits on touch

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -249,6 +249,8 @@ module Audited
             all_changes.except(*self.class.non_audited_columns)
           end
 
+        filtered_changes = normalize_enum_changes(filtered_changes)
+
         if for_touch && (last_audit = audits.last&.audited_changes)
           filtered_changes.reject! do |k, v|
             last_audit[k].to_json == v.to_json ||
@@ -258,7 +260,6 @@ module Audited
 
         filtered_changes = redact_values(filtered_changes)
         filtered_changes = filter_encrypted_attrs(filtered_changes)
-        filtered_changes = normalize_enum_changes(filtered_changes)
         filtered_changes.to_hash
       end
 

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -540,6 +540,14 @@ describe Audited::Auditor do
             expect(user.audits.last.action).to eq("update")
             expect(user.audits.last.audited_changes.keys).to eq(%w[suspended_at])
           end
+
+          it "updating nested resource through parent while changing an enum on parent shouldn't double audit" do
+            user.status = :reliable
+            user.companies_attributes = [{name: "test"}]
+            expect { user.save }.to change(user.audits, :count).from(1).to(2)
+            expect(user.audits.last.action).to eq("update")
+            expect(user.audits.last.audited_changes.keys).to eq(%w[status])
+          end
         end
 
         context "after updating" do

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -136,6 +136,7 @@ module Models
       has_associated_audits
       has_many :companies, class_name: "OwnedCompany", dependent: :destroy
       accepts_nested_attributes_for :companies
+      enum status: {active: 0, reliable: 1, banned: 2}
     end
 
     class OwnedCompany < ::ActiveRecord::Base


### PR DESCRIPTION
Closes #695