### PR TITLE
Fix audited on crash when run_conditional_check condition is true

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -408,7 +408,7 @@ module Audited
       end
 
       def run_conditional_check(condition, matching: true)
-        return true if condition.blank?
+        return true if condition.blank? or condition == true
         return condition.call(self) == matching if condition.respond_to?(:call)
         return send(condition) == matching if respond_to?(condition.to_sym, true)
 


### PR DESCRIPTION
The function `run_conditional_check ` crash when condition is set to true, as it tries to convert true to symbol

```ruby
      def run_conditional_check(condition, matching: true)
        return true if condition.blank?
        return condition.call(self) == matching if condition.respond_to?(:call)
        return send(condition) == matching if respond_to?(condition.to_sym, true
```

```
 #<NoMethodError: undefined method `to_sym' for true:TrueClass
Did you mean?  to_s>
E, [2024-01-31T15:43:09.682642 #2655809] ERROR -- : /usr/lib/rvm/gems/ruby-2.7.5@web/gems/audited-5.4.2/lib/audited/auditor.rb:412:in `run_conditional_check'
/usr/lib/rvm/gems/ruby-2.7.5@web/gems/audited-5.4.2/lib/audited/auditor.rb:403:in `auditing_enabled'
/usr/lib/rvm/gems/ruby-2.7.5@web/gems/audited-5.4.2/lib/audited/auditor.rb:359:in `write_audit'
/usr/lib/rvm/gems/ruby-2.7.5@web/gems/audited-5.4.2/lib/audited/auditor.rb:331:in `audit_create'
```

a good aproach is to set return to true if condition :if is true

```ruby
  audited on: [:create, :update, :destroy, :apply], if: MyApp::CONFIG[:audit_my_model]
```

```ruby
      def run_conditional_check(condition, matching: true)
        return true if condition.blank? or condition == true
        return condition.call(self) == matching if condition.respond_to?(:call)
        return send(condition) == matching if respond_to?(condition.to_sym, true)
```