### PR TITLE
Bump actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         sudo /etc/init.d/mysql start
         mysql -e 'CREATE DATABASE audited_test;' -uroot -proot
         mysql -e 'SHOW DATABASES;' -uroot -proot
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Copy Gemfile
       run: sed 's/\.\././' gemfiles/${{ matrix.appraisal }}.gemfile > Gemfile
     - name: Set up Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
GitHub is [planning to upgrade to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Versions prior to actions/checkout v3 use an outdated version of node, so we will upgrade to actions/checkout v4, where [Node 20 is the default](https://github.com/actions/checkout/releases/tag/v4.0.0).