### PR TITLE
Changes the way old audits are combined. Keep first and last value, discard middle ones.

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -188,7 +188,15 @@ module Audited
       # Combine multiple audits into one.
       def combine_audits(audits_to_combine)
         combine_target = audits_to_combine.last
-        combine_target.audited_changes = audits_to_combine.pluck(:audited_changes).reduce(&:merge)
+        combine_target.audited_changes = audits_to_combine.pluck(:audited_changes).reduce do |h1, h2|
+          h1.merge(h2) do |_key, this, other|
+            if this.is_a?(Array) && other.is_a?(Array)
+              [this.first, other.last]
+            else
+              other
+            end
+          end
+        end
         combine_target.comment = "#{combine_target.comment}\nThis audit is the result of multiple audits being combined."
 
         transaction do

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -706,7 +706,7 @@ describe Audited::Auditor do
         audits = user.audits
 
         expect(audits.count).to eq(3)
-        expect(audits[0].audited_changes).to include({"name" => ["Foobar", "Awesome"], "username" => ["brandon", "keepers"]})
+        expect(audits[0].audited_changes).to include({"name" => ["Brandon", "Awesome"], "username" => ["brandon", "keepers"]})
         expect(audits[1].audited_changes).to eq({"activated" => [nil, true]})
         expect(audits[2].audited_changes).to eq({"favourite_device" => [nil, "Android Phone"]})
       end


### PR DESCRIPTION
Changes the way old audits are combined. Now we keep the first and the last one of each attribute, instead of the last 2.