### PR TITLE
Do not restrain rails version

### DIFF
--- a/audited.gemspec
+++ b/audited.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activesupport", ">= 5.2", "< 7.2"
 
   gem.add_development_dependency "appraisal"
-  gem.add_development_dependency "rails", ">= 5.2", "< 7.2"
+  gem.add_development_dependency "rails", ">= 5.2"
   gem.add_development_dependency "rspec-rails"
   gem.add_development_dependency "standard"
   gem.add_development_dependency "single_cov"


### PR DESCRIPTION
This will allow applications running on rails main/master branch to easily use the gem 
+ Prepare for Rails 7.2.0 release that is about to be released

Let me know if I should update Appraisals to alors have a `main` appraisal pointing to rails main branch. Thanks