### PR TITLE
allow calling audited multiple times

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -59,9 +59,16 @@ module Audited
       #     end
       #
       def audited(options = {})
-        # don't allow multiple calls
-        return if included_modules.include?(Audited::Auditor::AuditedInstanceMethods)
+        audited? ? update_audited_options(options) : set_audit(options)
+      end
 
+      private
+
+      def audited?
+        included_modules.include?(Audited::Auditor::AuditedInstanceMethods)
+      end
+
+      def set_audit(options)
         extend Audited::Auditor::AuditedClassMethods
         include Audited::Auditor::AuditedInstanceMethods
 
@@ -69,10 +76,7 @@ module Audited
         class_attribute :audited_options, instance_writer: false
         attr_accessor :audit_version, :audit_comment
 
-        self.audited_options = options
-        normalize_audited_options
-
-        self.audit_associated_with = audited_options[:associated_with]
+        set_audited_options(options)
 
         if audited_options[:comment_required]
           validate :presence_of_audit_comment
@@ -99,6 +103,23 @@ module Audited
 
       def has_associated_audits
         has_many :associated_audits, as: :associated, class_name: Audited.audit_class.name
+      end
+
+      def update_audited_options(new_options)
+        previous_audit_options = self.audited_options
+        set_audited_options(new_options)
+        self.reset_audited_columns
+
+        log_message = "#{self.name} is already audited, audit options will be updated\n"\
+          "before: #{previous_audit_options}\n"\
+          "after: #{self.audited_options}"
+        Logger.new($stdout).info(log_message)
+      end
+
+      def set_audited_options(options)
+        self.audited_options = options
+        normalize_audited_options
+        self.audit_associated_with = audited_options[:associated_with]
       end
     end
 
@@ -529,6 +550,11 @@ module Audited
 
       def class_auditing_enabled
         Audited.store.fetch("#{table_name}_auditing_enabled", true)
+      end
+
+      def reset_audited_columns
+        @audited_columns = nil
+        @non_audited_columns = nil
       end
     end
   end

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -108,6 +108,9 @@ module Audited
       def update_audited_options(new_options)
         previous_audit_options = self.audited_options
         set_audited_options(new_options)
+
+        return if previous_audit_options == self.audited_options
+
         self.reset_audited_columns
 
         log_message = "#{self.name} is already audited, audit options will be updated\n"\

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -108,15 +108,7 @@ module Audited
       def update_audited_options(new_options)
         previous_audit_options = self.audited_options
         set_audited_options(new_options)
-
-        return if previous_audit_options == self.audited_options
-
         self.reset_audited_columns
-
-        log_message = "#{self.name} is already audited, audit options will be updated\n"\
-          "before: #{previous_audit_options}\n"\
-          "after: #{self.audited_options}"
-        Logger.new($stdout).info(log_message)
       end
 
       def set_audited_options(options)

--- a/spec/audited/auditor_spec.rb
+++ b/spec/audited/auditor_spec.rb
@@ -1270,4 +1270,20 @@ describe Audited::Auditor do
       }.to_not change(Audited::Audit, :count)
     end
   end
+
+  describe "call audit multiple times" do
+    it "should update audit options" do
+      user = Models::ActiveRecord::UserOnlyName.create
+      user.update(password: "new password 1", name: "new name 1")
+      expect(user.audits.last.audited_changes.keys).to eq(%w[name])
+
+      user.class.class_eval do
+        audited only: :password
+      end
+
+      user = Models::ActiveRecord::UserOnlyName.last
+      user.update(password: "new password 2", name: "new name 2")
+      expect(user.audits.last.audited_changes.keys).to eq(%w[password])
+    end
+  end
 end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -36,6 +36,12 @@ module Models
       audited only: :password
     end
 
+    class UserOnlyName < ::ActiveRecord::Base
+      self.table_name = :users
+      attribute :non_column_attr if Rails.gem_version >= Gem::Version.new("5.1")
+      audited only: :name
+    end
+
     class UserRedactedPassword < ::ActiveRecord::Base
       self.table_name = :users
       audited redacted: :password


### PR DESCRIPTION
Allow `audited` to be called multiple times

When `audited` is called for the first time, setup audit normally

However if `audited` is called on a class that is already audited we update `audit_options` and log a warning message

an example of the warning message logged:
![2024-10-21_18-22](https://github.com/user-attachments/assets/48484245-89de-4ee7-ae24-9707bdb7fd88)

Fixes #731 
