### PR TITLE
Relax gemspec to allow Rails 8.1

### DIFF
--- a/audited.gemspec
+++ b/audited.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.3.0"
 
-  gem.add_dependency "activerecord", ">= 5.2", "< 8.1"
-  gem.add_dependency "activesupport", ">= 5.2", "< 8.1"
+  gem.add_dependency "activerecord", ">= 5.2", "< 8.2"
+  gem.add_dependency "activesupport", ">= 5.2", "< 8.2"
 
   gem.add_development_dependency "appraisal"
-  gem.add_development_dependency "rails", ">= 5.2", "< 8.1"
+  gem.add_development_dependency "rails", ">= 5.2", "< 8.2"
   gem.add_development_dependency "rspec-rails"
   gem.add_development_dependency "standard"
   gem.add_development_dependency "single_cov"


### PR DESCRIPTION
Rails main is at 8.1 now, since we have test coverage for rails main branch already, it should be safe to allow rails 8.1 to install. Otherwise people using edge rails will install legacy 4.2.2 version, which doesn't work well.