### PR TITLE
Ensure that no audit-related queries run when auditing is disabled

### DIFF
--- a/lib/audited/rspec_matchers.rb
+++ b/lib/audited/rspec_matchers.rb
@@ -132,7 +132,7 @@ module Audited
 
       def validate_callbacks_include_presence_of_comment?
         if @options[:comment_required] && audited_on_create_or_update?
-          callbacks_for(:validate).include?(:presence_of_audit_comment)
+          callbacks_for(:validate).include?(:validate_presence_of_audit_comment)
         else
           true
         end


### PR DESCRIPTION
# Problem

Calling `Models::ActiveRecord::User.without_auditing { user.touch }` generates the query below:

```sql
SELECT "audits".* FROM "audits" WHERE "audits"."auditable_id" = ? AND "audits"."auditable_type" = ? ORDER BY "audits"."version" DESC LIMIT ?
```

Culprit: https://github.com/collectiveidea/audited/blob/f935285c27151dff179ef274776f865302d40b8d/lib/audited/auditor.rb#L361-L362

### Why this is a big deal

In an endpoint that requires high performance, I need to perform `record.touch(:connected_at)` along with some other audited record updates and make sure we're not running any extra queries.

# Solution

The current code checks for `auditing_enabled` too deep in the callback chain. Instead, we should use guards to return in each callback as early as possible.