### PR TITLE
Allow enable/disable Audit for all classes but only locally

### DIFF
--- a/lib/audited.rb
+++ b/lib/audited.rb
@@ -10,13 +10,12 @@ module Audited
 
   class << self
     attr_accessor \
-      :auditing_enabled,
       :current_user_method,
       :ignored_attributes,
       :ignored_default_callbacks,
       :max_audits,
       :store_synthesized_enums
-    attr_writer :audit_class
+    attr_writer :auditing_enabled, :audit_class
 
     def audit_class
       # The audit_class is set as String in the initializer. It can not be constantized during initialization and must
@@ -32,6 +31,32 @@ module Audited
 
     def store
       RequestStore.audited_store ||= {}
+    end
+
+    def auditing_enabled
+      store.key?(:auditing_enabled) ? store[:auditing_enabled] : @auditing_enabled
+    end
+
+    def with_auditing
+      before_value_in_store = store.delete(:auditing_enabled)
+      store[:auditing_enabled] = true
+
+      result = yield
+
+      store[:auditing_enabled] = before_value_in_store unless before_value_in_store.nil?
+
+      result
+    end
+
+    def without_auditing
+      before_value_in_store = store.delete(:auditing_enabled)
+      store[:auditing_enabled] = false
+
+      result = yield
+
+      store[:auditing_enabled] = before_value_in_store unless before_value_in_store.nil?
+
+      result
     end
 
     def config


### PR DESCRIPTION
It is already possible to disable Audits locally for a specific object or to an entire model

![image](https://github.com/user-attachments/assets/58ff8149-9168-47aa-b017-813c2adef3df)

but it not possible to do this to all classes. The only way would be to disable it at the module level with `Audited.auditing_enabled = false`, but this will disable audits for the entire process, which is undesirable in a multi-threaded environment like Sidekiq or Puma.

So I am opening this PR to suggest/add this feature.

Let me know if makes sense for the gem or if i need to make any changes to make it accepted.