### PR TITLE
Fix support for running without Rails

### DIFF
--- a/lib/audited/audit.rb
+++ b/lib/audited/audit.rb
@@ -49,7 +49,7 @@ module Audited
     cattr_accessor :audited_class_names
     self.audited_class_names = Set.new
 
-    if Rails.gem_version >= Gem::Version.new("7.1")
+    if ::ActiveRecord.version >= Gem::Version.new("7.1")
       serialize :audited_changes, coder: YAMLIfTextColumnType
     else
       serialize :audited_changes, YAMLIfTextColumnType

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -331,7 +331,7 @@ module Audited
       end
 
       def rails_below?(rails_version)
-        Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new(rails_version)
+        ::ActiveRecord.version < Gem::Version.new(rails_version)
       end
 
       def audits_to(version = nil)

--- a/lib/generators/audited/migration.rb
+++ b/lib/generators/audited/migration.rb
@@ -16,7 +16,7 @@ module Audited
       private
 
       def timestamped_migrations?
-        (Rails.gem_version >= Gem::Version.new("7.0")) ?
+        (::ActiveRecord.version >= Gem::Version.new("7.0")) ?
           ::ActiveRecord.timestamped_migrations :
           ::ActiveRecord::Base.timestamped_migrations
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,6 @@ Dir[SPEC_ROOT.join("support/*.rb")].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.include AuditedSpecHelpers
-  config.use_transactional_fixtures = false if Rails.version.start_with?("4.")
   config.use_transactional_tests = false if config.respond_to?(:use_transactional_tests=)
 end
 

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -5,16 +5,16 @@ module Models
   module ActiveRecord
     class User < ::ActiveRecord::Base
       audited except: :password
-      attribute :non_column_attr if Rails.gem_version >= Gem::Version.new("5.1")
+      attribute :non_column_attr if ::ActiveRecord.version >= Gem::Version.new("5.1")
       attr_protected :logins if respond_to?(:attr_protected)
 
-      if Rails.gem_version >= Gem::Version.new("7.2")
+      if ::ActiveRecord.version >= Gem::Version.new("7.2")
         enum :status, {active: 0, reliable: 1, banned: 2}
       else
         enum status: {active: 0, reliable: 1, banned: 2}
       end
 
-      if Rails.gem_version >= Gem::Version.new("7.1")
+      if ::ActiveRecord.version >= Gem::Version.new("7.1")
         serialize :phone_numbers, type: Array
       else
         serialize :phone_numbers, Array
@@ -32,13 +32,13 @@ module Models
 
     class UserOnlyPassword < ::ActiveRecord::Base
       self.table_name = :users
-      attribute :non_column_attr if Rails.gem_version >= Gem::Version.new("5.1")
+      attribute :non_column_attr if ::ActiveRecord.version >= Gem::Version.new("5.1")
       audited only: :password
     end
 
     class UserOnlyName < ::ActiveRecord::Base
       self.table_name = :users
-      attribute :non_column_attr if Rails.gem_version >= Gem::Version.new("5.1")
+      attribute :non_column_attr if ::ActiveRecord.version >= Gem::Version.new("5.1")
       audited only: :name
     end
 
@@ -148,7 +148,7 @@ module Models
       has_many :companies, class_name: "OwnedCompany", dependent: :destroy
       accepts_nested_attributes_for :companies
 
-      if Rails.gem_version >= Gem::Version.new("7.2")
+      if ::ActiveRecord.version >= Gem::Version.new("7.2")
         enum :status, {active: 0, reliable: 1, banned: 2}
       else
         enum status: {active: 0, reliable: 1, banned: 2}

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -2,7 +2,7 @@ require "active_record"
 require "logger"
 
 begin
-  if ActiveRecord.version >= Gem::Version.new("6.1.0")
+  if ::ActiveRecord.version >= Gem::Version.new("6.1.0")
     db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).first
     ActiveRecord::Tasks::DatabaseTasks.create(db_config)
   else


### PR DESCRIPTION
See https://github.com/collectiveidea/audited/pull/665. Some projects are just using ActiveRecord, and this gem does not officially depend on Rails.

However, this has never actually worked because of all the checks for `Rails.gem_version` around the codebase. Replacing them with `ActiveRecord.version` (which unlike `Rails.version`, returns a `Gem::Version` object) fixes this.

The test matrix should probably be updated to run both with and without full Rails