### PR TITLE
Add ruby3.4 and rails8.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
           sudo /etc/init.d/mysql start
           mysql -e 'CREATE DATABASE audited_test;' -uroot -proot
           mysql -e 'SHOW DATABASES;' -uroot -proot
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Copy Gemfile
         run: sed 's/\.\././' gemfiles/${{ matrix.appraisal }}.gemfile > Gemfile
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         appraisal:
           - rails52
           - rails60
@@ -19,6 +19,7 @@ jobs:
           - rails71
           - rails72
           - rails80
+          - rails81
           - rails_main
         db: [POSTGRES, MYSQL, SQLITE]
         exclude:
@@ -45,6 +46,8 @@ jobs:
             ruby: "3.2"
           - appraisal: rails52
             ruby: "3.3"
+          - appraisal: rails52
+            ruby: "3.4"
 
           # Rails 6.0 supports Ruby 2.5-2.7
           - appraisal: rails60
@@ -59,12 +62,16 @@ jobs:
             ruby: "3.2"
           - appraisal: rails60
             ruby: "3.3"
+          - appraisal: rails60
+            ruby: "3.4"
 
-          # Rails 6.1 supports Ruby 2.5+
+          # Rails 6.1 supports Ruby 2.5-3.3
           - appraisal: rails61
             ruby: "2.3"
           - appraisal: rails61
             ruby: "2.4"
+          - appraisal: rails61
+            ruby: "3.4"
 
           # Rails 7 supports Ruby 2.7+
           - appraisal: rails70
@@ -114,6 +121,22 @@ jobs:
           - appraisal: rails80
             ruby: "3.0"
           - appraisal: rails80
+            ruby: "3.1"
+
+          # Rails 8.1 supports Ruby 3.2+
+          - appraisal: rails81
+            ruby: "2.3"
+          - appraisal: rails81
+            ruby: "2.4"
+          - appraisal: rails81
+            ruby: "2.5"
+          - appraisal: rails81
+            ruby: "2.6"
+          - appraisal: rails81
+            ruby: "2.7"
+          - appraisal: rails81
+            ruby: "3.0"
+          - appraisal: rails81
             ruby: "3.1"
 
           # Rails main supports Ruby 3.2+

--- a/Appraisals
+++ b/Appraisals
@@ -52,9 +52,16 @@ appraise "rails80" do
   gem "sqlite3", ">= 1.4"
 end
 
+appraise "rails81" do
+  gem "rails", "~> 8.1.0"
+  gem "mysql2", "~> 0.5"
+  gem "pg", "~> 1.1"
+  gem "sqlite3", ">= 2.1"
+end
+
 appraise "rails_main" do
   gem "rails", github: "rails/rails", branch: "main"
   gem "mysql2", "~> 0.5"
   gem "pg", "~> 1.1"
-  gem "sqlite3", ">= 2.0"
+  gem "sqlite3", ">= 2.1"
 end

--- a/Appraisals
+++ b/Appraisals
@@ -15,6 +15,7 @@ appraise "rails60" do
   gem "mysql2", ">= 0.4.4"
   gem "pg", ">= 0.18", "< 2.0"
   gem "sqlite3", "~> 1.4"
+  gem "concurrent-ruby", "< 1.3.5"
 end
 
 appraise "rails61" do
@@ -22,6 +23,7 @@ appraise "rails61" do
   gem "mysql2", ">= 0.4.4"
   gem "pg", ">= 1.1", "< 2.0"
   gem "sqlite3", "~> 1.4"
+  gem "concurrent-ruby", "< 1.3.5"
 end
 
 appraise "rails70" do

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Audited
 **Audited** (previously acts_as_audited) is an ORM extension that logs all changes to your models. Audited can also record who made those changes, save comments and associate models related to the changes.
 
 
-Audited currently (5.6) works with Rails 7.2, 7.1, 7.0, 6.1, 6.0, 5.2.
+Audited currently (5.6) works with Rails 8.1, 8.0, 7.2, 7.1, 7.0, 6.1, 6.0, 5.2.
 
 For Rails 5.0 & 5.1, use gem version 5.4.3
 For Rails 4, use gem version 4.x
@@ -27,6 +27,7 @@ Audited supports and is [tested against](https://github.com/collectiveidea/audit
 * 3.1
 * 3.2
 * 3.3
+* 3.4
 
 Audited may work just fine with a Ruby version not listed above, but we can't guarantee that it will. If you'd like to maintain a Ruby that isn't listed, please let us know with a [pull request](https://github.com/collectiveidea/audited/pulls).
 

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -6,5 +6,6 @@ gem "rails", "~> 6.0.6"
 gem "mysql2", ">= 0.4.4"
 gem "pg", ">= 0.18", "< 2.0"
 gem "sqlite3", "~> 1.4"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec name: "audited", path: "../"

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -6,5 +6,6 @@ gem "rails", "~> 6.1.7"
 gem "mysql2", ">= 0.4.4"
 gem "pg", ">= 1.1", "< 2.0"
 gem "sqlite3", "~> 1.4"
+gem "concurrent-ruby", "< 1.3.5"
 
 gemspec name: "audited", path: "../"

--- a/gemfiles/rails81.gemfile
+++ b/gemfiles/rails81.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", github: "rails/rails", branch: "main"
+gem "rails", "~> 8.1.0"
 gem "mysql2", "~> 0.5"
 gem "pg", "~> 1.1"
 gem "sqlite3", ">= 2.1"

--- a/spec/audited/audit_spec.rb
+++ b/spec/audited/audit_spec.rb
@@ -72,7 +72,8 @@ describe Audited::Audit do
     it "does not unserialize from binary columns" do
       allow(Audited::YAMLIfTextColumnType).to receive(:text_column?).and_return(false)
       audit.audited_changes = {foo: "bar"}
-      expect(audit.audited_changes).to eq "{:foo=>\"bar\"}"
+      expected = RUBY_VERSION >= "3.4" ? "{foo: \"bar\"}" : "{:foo=>\"bar\"}"
+      expect(audit.audited_changes).to eq expected
     end
   end
 


### PR DESCRIPTION
- Add Ruby 3.4 and Rails 8.1 to the CI matrix and fixed all failing tests
- Upgrade actions/update to the latest version
- CI result is [here](https://github.com/willnet/audited/actions/runs/20094260302)