### PR TITLE
ruby 4.0 support: add benchmark and cgi development dependencies

### DIFF
--- a/audited.gemspec
+++ b/audited.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activesupport", ">= 5.2", "< 8.2"
 
   gem.add_development_dependency "appraisal"
+  gem.add_development_dependency "benchmark"
+  gem.add_development_dependency "cgi"
   gem.add_development_dependency "rails", ">= 5.2", "< 8.2"
   gem.add_development_dependency "rspec-rails"
   gem.add_development_dependency "standard"


### PR DESCRIPTION
These gems were separated from ruby core v4.0, adding them for supporting next ruby version.