### PR TITLE
Eliminate `audits.last` query when filtering touch changes

### DIFF
--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -267,7 +267,7 @@ module Audited
 
         filtered_changes = normalize_enum_changes(filtered_changes)
 
-        if for_touch && (last_audit = audits.last&.audited_changes)
+        if for_touch && (last_audit = @last_audited_changes)
           filtered_changes.reject! do |k, v|
             last_audit[k].to_json == v.to_json ||
             last_audit[k].to_json == v[1].to_json
@@ -380,6 +380,7 @@ module Audited
 
           run_callbacks(:audit) {
             audit = audits.create(attrs)
+            @last_audited_changes = attrs[:audited_changes] if audit.persisted?
             combine_audits_if_needed if attrs[:action] != "create"
             audit
           }

--- a/lib/audited/auditor.rb
+++ b/lib/audited/auditor.rb
@@ -267,10 +267,10 @@ module Audited
 
         filtered_changes = normalize_enum_changes(filtered_changes)
 
-        if for_touch && (last_audit = @last_audited_changes)
+        if for_touch && @last_audited_changes
           filtered_changes.reject! do |k, v|
-            last_audit[k].to_json == v.to_json ||
-            last_audit[k].to_json == v[1].to_json
+            @last_audited_changes[k].to_json == v.to_json ||
+            @last_audited_changes[k].to_json == v[1].to_json
           end
         end
 


### PR DESCRIPTION
This change is an optimization for the fix introduced in https://github.com/collectiveidea/audited/pull/660

Cache the last audit changes on the instance to remove the `audits.last` query when filtering changes in `audited_changes`.